### PR TITLE
Basic Tidal Mini Notation Parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ crossbeam-channel = { version = "^0.5", optional = true }
 afplay = { git = "https://github.com/emuell/afplay", default-features = false, features = [
     "cpal-output",
 ], optional = true }
+fraction = { version = "0.15.2" }
 
 [dev-dependencies]
 notify = { version = "^6.1" }

--- a/src/rhythm/tidal.pest
+++ b/src/rhythm/tidal.pest
@@ -42,9 +42,9 @@ op_range     = { ".." ~ parameter } // ???
 op = _{ op_weight | op_bjorklund | op_slow | op_fast | op_replicate | op_degrade | op_tail | op_range }
 
 /// groups
-subdivision     = { "[" ~ (stack | choices | section) ~ "]" }
-alternating     = { "<" ~ (stack | section) ~ ">" }
-polymeter       = { "{" ~ (stack | section) ~ "}" ~ polymeter_tail }
+subdivision     = { "[" ~ (stack | choices | section)? ~ "]" }
+alternating     = { "<" ~ (stack | section)? ~ ">" }
+polymeter       = { "{" ~ (stack | section)? ~ "}" ~ polymeter_tail }
 polymeter_tail  = { "%" ~  polymeter_count}
 polymeter_count = { (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* ~ !(ASCII_ALPHANUMERIC | "."))}
 

--- a/src/rhythm/tidal.pest
+++ b/src/rhythm/tidal.pest
@@ -1,56 +1,74 @@
-// PEST parser definition for tidal mini-notations, based
-// on the TidalCycles mini-notation parser by Alex McLean.
+//! pest parser grammar for mini-notations, based
+//! on the TidalCycles mini-notation parser by Alex McLean.
 
-// numbers
-number        = @{ minus? ~ int ~ frac? ~ exp? }
-decimal_point = _{ "." }
-digit1_9      = _{ '1'..'9' }
-e             = _{ "e" | "E" }
-exp           = _{ e ~ (minus | plus)? ~ ASCII_DIGIT+ }
-frac          = _{ decimal_point ~ ASCII_DIGIT+ }
-int           = _{ zero | (digit1_9 ~ ASCII_DIGIT*) }
-minus         = _{ "-" }
-plus          = _{ "+" }
-zero          = _{ "0" }
-
-// delimiters
-comma = _{ "," }
-pipe  = _{ "|" }
-dot   = _{ "." }
-
-// character classes
+// define whitespaces as space, tab and non-breaking space
 WHITESPACE = _{ " " | "\t" | "\u{A0}" }
 
-// mini
-step_char = _{ ASCII_ALPHA | ASCII_DIGIT | "~" | "-" | "#" | "." | "^" | "_" }
-step      = @{ step_char+ }
+/// numbers types allowing [ "1" "1.0" "1." ".1" ]
+digit   = @{("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)}
+integer = @{ "-"? ~ digit}
+normal  = @{ "-"? ~ "." ~ digit }
+float   = @{ "-"? ~ digit ~ "." ~ (digit)* }
+// exp           = _{ ^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+number  = ${ (normal | float | integer) ~ !(ASCII_ALPHA) }
 
-sub_cycle       = { "[" ~ stack_or_choose ~ "]" }
-polymeter       = { "{" ~ polymeter_stack ~ "}" ~ polymeter_steps? }
-polymeter_steps = { "%" ~ slice }
+/// case-incensitive pitch type with note, optional octave and sharp or flat mark
+octave  = { "10" | ASCII_DIGIT }
+mark    = { "#"|"b" }
+note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
+pitch   = ${ note ~ mark? ~ octave? ~ !(ASCII_ALPHANUMERIC)}
 
-slow_sequence = { "<" ~ polymeter_stack ~ ">" }
+/// type for empty steps
+rest = { "~" ~ !(ASCII_ALPHANUMERIC) }
 
-slice    = _{ step | sub_cycle | polymeter | slow_sequence }
-slice_op = _{ op_weight | op_bjorklund | op_slow | op_fast | op_replicate | op_degrade | op_tail | op_range }
+/// type for held steps
+hold = { "_" ~ !(ASCII_ALPHANUMERIC) }
 
-op_weight    = { ("@" | "_") ~ number }
+/// arbitrary string identifier type
+name = { (ASCII_ALPHANUMERIC | "_")+ }
+
+/// possible literals for single steps
+single = { hold | rest | number | pitch | name }
+
+/// operators
+op_weight    = { ("@" | "_") ~ parameter }
 op_replicate = { "!" }
-op_bjorklund = { "(" ~ (slice_with_ops ~ comma)+ ~ slice_with_ops ~ ")" }
-op_slow      = { "/" ~ number }
-op_fast      = { "*" ~ number }
-op_degrade   = { "?" ~ number }
-op_tail      = { ":" ~ number }
-op_range     = { ".." ~ number } // ???
+op_bjorklund = { "(" ~ (parameter ~ ",")+ ~ parameter ~ ")" }
+op_slow      = { "/" ~ parameter }
+op_fast      = { "*" ~ parameter }
+op_degrade   = { "?" ~ parameter }
+op_tail      = { ":" ~ parameter }
+op_range     = { ".." ~ parameter } // ???
+op = _{ op_weight | op_bjorklund | op_slow | op_fast | op_replicate | op_degrade | op_tail | op_range }
 
-slice_with_ops = _{ slice ~ slice_op* }
-sequence       = _{ slice_with_ops+ }
+/// groups
+subdivision     = { "[" ~ (stack | choices | section) ~ "]" }
+alternating     = { "<" ~ (stack | section) ~ ">" }
+polymeter       = { "{" ~ (stack | section) ~ "}" ~ polymeter_tail }
+polymeter_tail  = { "%" ~  polymeter_count}
+polymeter_count = { (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* ~ !(ASCII_ALPHANUMERIC | "."))}
 
-stack_tail  = { (comma ~ sequence)+ }
-choose_tail = { (pipe ~ sequence)+ }
-dot_tail    = { (dot ~ sequence)+ }
+group     = _{ subdivision | alternating | polymeter }
 
-stack_or_choose = _{ sequence ~ (stack_tail | choose_tail | dot_tail)? }
-polymeter_stack = _{ sequence ~ stack_tail? }
+// this should actually be { expr | group | number } at some point
+/// parameter for expressions with operators
+parameter = _{ number }
 
-mini = { SOI ~ stack_or_choose ~ EOI }
+expr      = { (single | group) ~ op+ }
+
+/// helper container that splits steps into sections
+section   = { (expr | single | group)+ }
+
+/// a single choice inside a choice list
+choice    = { expr | single | group }
+/// at least 2 choices, can only be inside subdivisions or the root
+choices   = { (choice) ~ ("|" ~ choice)+ }
+
+/// parallel sections of events found inside groups
+stack     = { (section) ~ ("," ~ section)+ }
+
+// shorthand for subdivisions
+// split          = { (section) ~ ("." ~ section)+ }
+
+/// the root of the cycle
+mini = { SOI ~ ( stack | choices | section) ~ (EOI | NEWLINE) }

--- a/src/rhythm/tidal.pest
+++ b/src/rhythm/tidal.pest
@@ -31,15 +31,15 @@ name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 single = { hold | rest | number | pitch | name }
 
 /// operators
-op_weight    = @{ ("@") ~ parameter }
-op_replicate = @{ "!" }
-op_bjorklund = @{ "(" ~ (parameter ~ ",")+ ~ parameter ~ ")" }
-op_slow      = @{ "/" ~ parameter }
-op_fast      = @{ "*" ~ parameter }
-op_degrade   = @{ "?" ~ parameter }
-op_tail      = @{ ":" ~ parameter }
-op_range     = { ".." ~ parameter } // ???
-op = _{ op_weight | op_bjorklund | op_slow | op_fast | op_replicate | op_degrade | op_tail | op_range }
+op_fast      = ${ "*" ~ parameter }
+op_target    = ${ ":" ~ parameter }
+op_degrade   = ${ "?" ~ parameter }
+op_replicate = ${ "!" ~ parameter }
+op_bjorklund = { "(" ~ (parameter ~ ",")+ ~ parameter ~ ")" }
+// op_weight    = ${ ("@") ~ parameter }
+// op_slow      = ${ "/" ~ parameter }
+// op_range     = { ".." ~ parameter } // ???
+op = _{ op_fast | op_target | op_degrade | op_replicate | op_bjorklund }
 
 /// groups
 subdivision     = { "[" ~ (stack | choices | section)? ~ "]" }
@@ -50,9 +50,9 @@ polymeter_count = { (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* ~ !(ASCII_ALPHANUMERIC |
 
 group     = _{ subdivision | alternating | polymeter }
 
-// this should actually be { expr | group | number } at some point
+// this should actually be { expr | group | single } at some point
 /// parameter for expressions with operators
-parameter = _{ number }
+parameter = _{ single }
 
 expr      = { (single | group) ~ op+ }
 

--- a/src/rhythm/tidal.pest
+++ b/src/rhythm/tidal.pest
@@ -25,7 +25,7 @@ rest = { "~" ~ !(ASCII_ALPHANUMERIC) }
 hold = { "_" ~ !(ASCII_ALPHANUMERIC) }
 
 /// arbitrary string identifier type
-name = { (ASCII_ALPHANUMERIC | "_")+ }
+name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 
 /// possible literals for single steps
 single = { hold | rest | number | pitch | name }

--- a/src/rhythm/tidal.pest
+++ b/src/rhythm/tidal.pest
@@ -19,10 +19,10 @@ note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
 pitch   = ${ note ~ mark? ~ octave? ~ !(ASCII_ALPHANUMERIC)}
 
 /// type for empty steps
-rest = { "~" ~ !(ASCII_ALPHANUMERIC) }
+rest = @{ "~" ~ !(ASCII_ALPHANUMERIC) }
 
 /// type for held steps
-hold = { "_" ~ !(ASCII_ALPHANUMERIC) }
+hold = @{ "_" ~ !(ASCII_ALPHANUMERIC) }
 
 /// arbitrary string identifier type
 name = @{ (ASCII_ALPHANUMERIC | "_")+ }
@@ -31,13 +31,13 @@ name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 single = { hold | rest | number | pitch | name }
 
 /// operators
-op_weight    = { ("@" | "_") ~ parameter }
-op_replicate = { "!" }
-op_bjorklund = { "(" ~ (parameter ~ ",")+ ~ parameter ~ ")" }
-op_slow      = { "/" ~ parameter }
-op_fast      = { "*" ~ parameter }
-op_degrade   = { "?" ~ parameter }
-op_tail      = { ":" ~ parameter }
+op_weight    = @{ ("@") ~ parameter }
+op_replicate = @{ "!" }
+op_bjorklund = @{ "(" ~ (parameter ~ ",")+ ~ parameter ~ ")" }
+op_slow      = @{ "/" ~ parameter }
+op_fast      = @{ "*" ~ parameter }
+op_degrade   = @{ "?" ~ parameter }
+op_tail      = @{ ":" ~ parameter }
 op_range     = { ".." ~ parameter } // ???
 op = _{ op_weight | op_bjorklund | op_slow | op_fast | op_replicate | op_degrade | op_tail | op_range }
 

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -613,6 +613,7 @@ mod test {
         match MiniParser::parse(Rule::mini, &input) {
             Ok(mut tree) => {
                 let mini = tree.next().unwrap();
+                println!("\nTREE");
                 print_pairs(&mini, 0);
                 match parse_tree(&mini) {
                     Ok(mut step) => {

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -25,7 +25,7 @@ struct Pitch {
 #[derive(Clone, Debug)]
 enum StepValue {
     Float(f64),
-    Integer(u32),
+    Integer(i32),
     Pitch(Pitch),
     Name(String),
     Rest,
@@ -303,7 +303,7 @@ fn as_value(pair: Pair<Rule>) -> StepValue {
         Rule::number => {
             if let Some(n) = pair.into_inner().next() {
                 match n.as_rule() {
-                    Rule::integer => StepValue::Integer(n.as_str().parse::<u32>().unwrap_or(0)),
+                    Rule::integer => StepValue::Integer(n.as_str().parse::<i32>().unwrap_or(0)),
                     Rule::float => StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)),
                     Rule::normal => StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)),
                     _ => unreachable!(),

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -30,10 +30,7 @@ impl Pitch {
     }
 
     fn parse(pair: Pair<Rule>) -> Pitch {
-        let mut pitch = Pitch {
-            note: 0,
-            octave: 4,
-        };
+        let mut pitch = Pitch { note: 0, octave: 4 };
         let mut mark: i8 = 0;
         for p in pair.into_inner() {
             match p.as_rule() {
@@ -57,18 +54,17 @@ impl Pitch {
                 pitch.octave -= 1;
                 pitch.note = 11 as u8;
             }
-        }else if pitch.note == 11 && mark == 1{
+        } else if pitch.note == 11 && mark == 1 {
             if pitch.octave < 10 {
                 pitch.note = 0;
                 pitch.octave += 1;
             }
-        }else{
+        } else {
             pitch.note = ((pitch.note as i8) + mark) as u8;
         }
         // pitch.note = pitch.note.clamp(0, 127);
         pitch
     }
-
 }
 
 #[derive(Clone, Debug)]
@@ -89,12 +85,9 @@ impl Step {
             Some(pair) => {
                 let string = pair.as_str().to_string();
                 let value = StepValue::parse(pair)?;
-                Ok(Step::Single(Single{
-                    string,
-                    value,
-                }))
+                Ok(Step::Single(Single { string, value }))
             }
-            None => Err("empty single".to_string())
+            None => Err("empty single".to_string()),
         }
     }
 }
@@ -109,7 +102,7 @@ impl Single {
     fn default() -> Self {
         Single {
             value: StepValue::Rest,
-            string: String::from("~")
+            string: String::from("~"),
         }
     }
     fn to_integer(&self) -> Option<i32> {
@@ -174,12 +167,12 @@ struct Stack {
 
 #[derive(Clone, Debug)]
 enum Operator {
-    Fast(),       // *
-    Target(),     // :
-    Degrade(),    // ?
-    Replicate(),  // !
-    // Weight(),     // @
-    // Slow(),       // /
+    Fast(),    // *
+    Target(),  // :
+    Degrade(), // ?
+    Replicate(), // !
+               // Weight(),     // @
+               // Slow(),       // /
 }
 impl Operator {
     fn parse(pair: Pair<Rule>) -> Result<Operator, String> {
@@ -188,7 +181,7 @@ impl Operator {
             Rule::op_target => Ok(Operator::Target()),
             Rule::op_degrade => Ok(Operator::Degrade()),
             Rule::op_replicate => Ok(Operator::Replicate()),
-            _ => Err(format!("unsupported operator: {:?}", pair.as_rule()))
+            _ => Err(format!("unsupported operator: {:?}", pair.as_rule())),
         }
     }
 }
@@ -210,7 +203,8 @@ struct Bjorklund {
 
 #[derive(Clone, Debug, Default)]
 enum StepValue {
-    #[default] Rest,
+    #[default]
+    Rest,
     Hold,
     Float(f64),
     Integer(i32),
@@ -227,9 +221,15 @@ impl StepValue {
             Rule::number => {
                 if let Some(n) = pair.into_inner().next() {
                     match n.as_rule() {
-                        Rule::integer => Ok(StepValue::Integer(n.as_str().parse::<i32>().unwrap_or(0))),
-                        Rule::float => Ok(StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0))),
-                        Rule::normal => Ok(StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0))),
+                        Rule::integer => {
+                            Ok(StepValue::Integer(n.as_str().parse::<i32>().unwrap_or(0)))
+                        }
+                        Rule::float => {
+                            Ok(StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)))
+                        }
+                        Rule::normal => {
+                            Ok(StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)))
+                        }
                         _ => Err(format!("unrecognized number\n{:?}", n)),
                     }
                 } else {
@@ -264,9 +264,9 @@ impl Span {
         self.end - self.start
     }
     fn default() -> Self {
-        Span{
-            start : 0.0,
-            end : 1.0
+        Span {
+            start: 0.0,
+            end: 1.0,
         }
     }
     fn new(start: f64, end: f64) -> Self {
@@ -276,7 +276,8 @@ impl Span {
 
 #[derive(Clone, Debug, Default)]
 enum Target {
-    #[default] None,
+    #[default]
+    None,
     Index(i32),
     Name(String),
 }
@@ -288,8 +289,7 @@ impl Display for Target {
             _ => {
                 f.write_fmt(format_args!(
                     "{:?}",
-                    self
-                    // self.span.start, self.span.end, self.value
+                    self // self.span.start, self.span.end, self.value
                 ))
             }
         }
@@ -301,18 +301,20 @@ struct SingleEvent {
     length: f64,
     span: Span,
     value: StepValue,
-    target : Target, // value for instruments
+    target: Target, // value for instruments
 }
 
 impl Display for SingleEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
             "{:.3} -> {:.3} | {:?} {}",
-            self.span.start, self.span.end, self.value, self.target
-            // self.span.start, self.span.end, self.value
+            self.span.start,
+            self.span.end,
+            self.value,
+            self.target // self.span.start, self.span.end, self.value
         ))
     }
-} 
+}
 
 #[derive(Debug, Clone)]
 struct MultiEvents {
@@ -337,15 +339,15 @@ enum Events {
 
 impl Events {
     fn empty() -> Events {
-        Events::Single(SingleEvent{
+        Events::Single(SingleEvent {
             length: 1.0,
             span: Span::default(),
             value: StepValue::Rest,
-            target: Target::None
+            target: Target::None,
         })
     }
     // only applied for Subdivision and Polymeter groups
-    fn subdivide_lengths(events: &mut Vec<Events>){
+    fn subdivide_lengths(events: &mut Vec<Events>) {
         let mut length = 0.0;
         for e in &mut *events {
             match e {
@@ -360,17 +362,17 @@ impl Events {
             match e {
                 Events::Single(s) => {
                     s.length *= step_size;
-                    s.span  = Span::new(start, start + s.length);
+                    s.span = Span::new(start, start + s.length);
                     start += s.length
                 }
                 Events::Multi(m) => {
                     m.length *= step_size;
-                    m.span  = Span::new(start, start + m.length);
+                    m.span = Span::new(start, start + m.length);
                     start += m.length
                 }
                 Events::Poly(p) => {
                     p.length *= step_size;
-                    p.span  = Span::new(start, start + p.length);
+                    p.span = Span::new(start, start + p.length);
                     start += p.length
                 }
             }
@@ -396,14 +398,12 @@ impl Events {
             }
         }
     }
-    fn flatten(&self, channels: &mut Vec<Vec<SingleEvent>>, channel: usize){
+    fn flatten(&self, channels: &mut Vec<Vec<SingleEvent>>, channel: usize) {
         if channels.len() <= channel {
             channels.push(vec![])
         }
         match self {
-            Events::Single(s) => {
-                channels[channel].push(s.clone())
-            }
+            Events::Single(s) => channels[channel].push(s.clone()),
             Events::Multi(m) => {
                 for e in &m.events {
                     e.flatten(channels, channel);
@@ -428,7 +428,6 @@ pub struct Cycle {
 }
 
 impl Cycle {
-
     // stacks can only appear inside groups like Subdivision, Alternating or Polymeter
     // they will have a stack of steps with their parent's type inside
     fn parse_stack(pair: Pair<Rule>, parent: Pair<Rule>) -> Result<Step, String> {
@@ -444,24 +443,22 @@ impl Cycle {
             _ => return Err(format!("invalid parent to stack\n{:?}", parent)),
         }
 
-        let mut stack = Stack {
-            stack: vec![]
-        };
+        let mut stack = Stack { stack: vec![] };
 
         match parent.as_rule() {
             Rule::alternating => {
                 for c in channels {
                     stack.stack.push(Step::Alternating(Alternating {
                         current: 0,
-                        steps: c
+                        steps: c,
                     }))
                 }
             }
             Rule::subdivision | Rule::mini => {
                 for c in channels {
-                    stack.stack.push(Step::Subdivision(Subdivision {
-                        steps: c
-                    }))
+                    stack
+                        .stack
+                        .push(Step::Subdivision(Subdivision { steps: c }))
                 }
             }
             Rule::polymeter => {
@@ -478,7 +475,6 @@ impl Cycle {
         }
         Ok(Step::Stack(stack))
     }
-
 
     fn parse_polymeter_count(pair: &Pair<Rule>) -> Result<usize, String> {
         for p in pair.clone().into_inner() {
@@ -543,40 +539,31 @@ impl Cycle {
                     let single = Step::parse_single(inner)?;
                     Ok(vec![single])
                 }
-                Rule::section => {
-                    Cycle::parse_section(inner)
-                }
+                Rule::section => Cycle::parse_section(inner),
                 Rule::choices => {
                     let mut choices: Vec<Step> = vec![];
                     for p in inner.clone().into_inner() {
                         if let Some(step) = p.into_inner().next() {
                             let choice = Cycle::parse_step(step)?;
                             choices.push(choice)
-                        }else{
-                            return Err(format!("empty choice\n{:?}", inner))
+                        } else {
+                            return Err(format!("empty choice\n{:?}", inner));
                         }
                     }
-                    Ok(vec![Step::Choices(Choices {
-                        choices,
-                    })])
+                    Ok(vec![Step::Choices(Choices { choices })])
                 }
-                _ => {
-                    Err(format!("unexpected rule in section\n{:?}", inner))
-                }
+                _ => Err(format!("unexpected rule in section\n{:?}", inner)),
             }
         } else {
             Err("empty section".to_string())
         }
     }
 
-
     // recursively parse a pair as a Step
     // errors here should be unreachable unless there is a bug in the pest grammar
     fn parse_step(pair: Pair<Rule>) -> Result<Step, String> {
         match pair.as_rule() {
-            Rule::single => {
-                Step::parse_single(pair)
-            }
+            Rule::single => Step::parse_single(pair),
             Rule::subdivision | Rule::mini => {
                 if let Some(first) = pair.clone().into_inner().next() {
                     match first.as_rule() {
@@ -633,39 +620,41 @@ impl Cycle {
                         let left = Cycle::parse_step(left_pair)?;
                         match inner.next() {
                             None => Err(format!("incomplete expression\n{:?}", pair)),
-                            Some(op) => {
-                                match op.as_rule() {
-                                    Rule::op_bjorklund => {
-                                        let mut op_inner = op.into_inner();
-                                        if let Some(pulse_pair) = op_inner.next() {
-                                            let pulses = Cycle::parse_step(pulse_pair)?;
-                                            if let Some(steps_pair) = op_inner.next() {
-                                                let steps = Cycle::parse_step(steps_pair)?;
-                                                let mut rotate = None;
-                                                if let Some(rotate_pair) = op_inner.next() {
-                                                    rotate = Some(Cycle::parse_step(rotate_pair)?);
-                                                }
-                                                return Ok(Step::Bjorklund(Bjorklund{
-                                                    left: Box::new(left),
-                                                    pulses: Box::new(pulses),
-                                                    steps: Box::new(steps),
-                                                    rotation: match rotate {
-                                                        Some(r) => Some(Box::new(r)),
-                                                        None => None
-                                                    }
-                                                }))
+                            Some(op) => match op.as_rule() {
+                                Rule::op_bjorklund => {
+                                    let mut op_inner = op.into_inner();
+                                    if let Some(pulse_pair) = op_inner.next() {
+                                        let pulses = Cycle::parse_step(pulse_pair)?;
+                                        if let Some(steps_pair) = op_inner.next() {
+                                            let steps = Cycle::parse_step(steps_pair)?;
+                                            let mut rotate = None;
+                                            if let Some(rotate_pair) = op_inner.next() {
+                                                rotate = Some(Cycle::parse_step(rotate_pair)?);
                                             }
+                                            return Ok(Step::Bjorklund(Bjorklund {
+                                                left: Box::new(left),
+                                                pulses: Box::new(pulses),
+                                                steps: Box::new(steps),
+                                                rotation: match rotate {
+                                                    Some(r) => Some(Box::new(r)),
+                                                    None => None,
+                                                },
+                                            }));
                                         }
-                                        return Err(format!("invalid bjorklund\n{:?}", pair))
                                     }
-                                    _ => {
-                                        let operator = Operator::parse(op.clone())?;
-                                        let mut inner = op.into_inner();
-                                        match inner.next() {
-                                            None => Err(format!("missing right hand side in expression\n{:?}", inner)),
-                                            Some(right_pair) => {
-                                                let right = Cycle::parse_step(right_pair)?;
-                                                match right {
+                                    return Err(format!("invalid bjorklund\n{:?}", pair));
+                                }
+                                _ => {
+                                    let operator = Operator::parse(op.clone())?;
+                                    let mut inner = op.into_inner();
+                                    match inner.next() {
+                                        None => Err(format!(
+                                            "missing right hand side in expression\n{:?}",
+                                            inner
+                                        )),
+                                        Some(right_pair) => {
+                                            let right = Cycle::parse_step(right_pair)?;
+                                            match right {
                                                     Step::Single(_) =>{
                                                         let expr = Step::Expression(Expression {
                                                             left: Box::new(left),
@@ -676,18 +665,15 @@ impl Cycle {
                                                     }
                                                     _ => Err("only single values are supported on the right hand side".to_string())
                                                 }
-                                            }
                                         }
                                     }
                                 }
-                            }
+                            },
                         }
                     }
                 }
             }
-            _ => {
-                Err(format!("rule not implemented\n{:?}", pair))
-            }
+            _ => Err(format!("rule not implemented\n{:?}", pair)),
         }
     }
 
@@ -751,14 +737,12 @@ impl Cycle {
     // recursively output events for the entire cycle based on some state (random seed)
     fn output(step: &mut Step, rng: &mut Xoshiro256PlusPlus) -> Events {
         match step {
-            Step::Single(s) => {
-                Events::Single(SingleEvent {
-                    length: 1.0,
-                    target : Target::None,
-                    span: Span::default(),
-                    value: s.value.clone(),
-                })
-            }
+            Step::Single(s) => Events::Single(SingleEvent {
+                length: 1.0,
+                target: Target::None,
+                span: Span::default(),
+                value: s.value.clone(),
+            }),
             Step::Subdivision(sd) => {
                 if sd.steps.len() == 0 {
                     Events::empty()
@@ -771,10 +755,10 @@ impl Cycle {
                     }
                     // only applied for Subdivision and Polymeter groups
                     Events::subdivide_lengths(&mut events);
-                    Events::Multi(MultiEvents{
+                    Events::Multi(MultiEvents {
                         span: Span::default(),
                         length: 1.0,
-                        events
+                        events,
                     })
                 }
             }
@@ -802,20 +786,20 @@ impl Cycle {
                     let mut events = vec![];
                     let length = pm.steps.len();
                     let offset = pm.offset;
-                    
+
                     for i in 0..pm.count {
                         events.push(Cycle::output(
                             &mut pm.steps[(offset + i) % length].clone(),
-                            rng
+                            rng,
                         ))
                     }
                     pm.offset += pm.count;
                     // only applied for Subdivision and Polymeter groups
                     Events::subdivide_lengths(&mut events);
-                    Events::Multi(MultiEvents{
+                    Events::Multi(MultiEvents {
                         span: Span::default(),
                         length: 1.0,
-                        events
+                        events,
                     })
                 }
             }
@@ -827,10 +811,10 @@ impl Cycle {
                     for s in &mut st.stack {
                         channels.push(Cycle::output(s, rng))
                     }
-                    Events::Poly(PolyEvents{
+                    Events::Poly(PolyEvents {
                         span: Span::default(),
-                        length:1.0,
-                        channels
+                        length: 1.0,
+                        channels,
                     })
                 }
             }
@@ -840,13 +824,13 @@ impl Cycle {
                         let mut events = vec![];
                         match e.right.as_ref() {
                             Step::Single(s) => {
-                                if let Some(mult) = s.to_integer(){
-                                    for _i in 0..mult{
+                                if let Some(mult) = s.to_integer() {
+                                    for _i in 0..mult {
                                         events.push(Cycle::output(&mut e.left, rng))
                                     }
                                 }
                             }
-                            _ => () // TODO support something other than Step::Single as the right hand side
+                            _ => (), // TODO support something other than Step::Single as the right hand side
                         }
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
@@ -858,28 +842,22 @@ impl Cycle {
                     Operator::Target() => {
                         let mut out = Cycle::output(e.left.as_mut(), rng);
                         match e.right.as_ref() {
-                            Step::Single(s) => {
-                                out.mutate_events(&mut |e| 
-                                    e.target = s.to_target()
-                                )
-                            }
-                            _ => () // TODO support something other than Step::Single as the right hand side
+                            Step::Single(s) => out.mutate_events(&mut |e| e.target = s.to_target()),
+                            _ => (), // TODO support something other than Step::Single as the right hand side
                         }
                         out
                     }
                     Operator::Degrade() => {
                         let mut out = Cycle::output(e.left.as_mut(), rng);
                         match e.right.as_ref() {
-                            Step::Single(s) => {
-                                out.mutate_events(&mut |e : &mut SingleEvent|
-                                    if let Some(chance) = s.to_chance(){
-                                        if chance < rng.gen_range(0.0..1.0) {
-                                            e.value = StepValue::Rest
-                                        }
+                            Step::Single(s) => out.mutate_events(&mut |e: &mut SingleEvent| {
+                                if let Some(chance) = s.to_chance() {
+                                    if chance < rng.gen_range(0.0..1.0) {
+                                        e.value = StepValue::Rest
                                     }
-                                )
-                            }
-                            _ => () // TODO support something other than Step::Single as the right hand side
+                                }
+                            }),
+                            _ => (), // TODO support something other than Step::Single as the right hand side
                         }
                         out
                     }
@@ -887,14 +865,14 @@ impl Cycle {
                         let mut events = vec![];
                         match e.right.as_ref() {
                             Step::Single(s) => {
-                                if let Some(mult) = s.to_integer(){
+                                if let Some(mult) = s.to_integer() {
                                     let out = Cycle::output(&mut e.left, rng);
-                                    for _i in 0..mult{
+                                    for _i in 0..mult {
                                         events.push(out.clone())
                                     }
                                 }
                             }
-                            _ => () // TODO support something other than Step::Single as the right hand side
+                            _ => (), // TODO support something other than Step::Single as the right hand side
                         }
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
@@ -909,38 +887,40 @@ impl Cycle {
                 let mut events = vec![];
                 match b.pulses.as_ref() {
                     Step::Single(pulses_single) => {
-                        match b.steps.as_ref(){
+                        match b.steps.as_ref() {
                             Step::Single(steps_single) => {
                                 let rotation = match &b.rotation {
                                     Some(r) => match r.as_ref() {
                                         Step::Single(rotation_single) => {
                                             if let Some(r) = rotation_single.to_integer() {
                                                 Some(r)
-                                            }else{
+                                            } else {
                                                 None
                                             }
                                         }
-                                        _ => None // TODO support something other than Step::Single as rotation
-                                    }
-                                    None => None
+                                        _ => None, // TODO support something other than Step::Single as rotation
+                                    },
+                                    None => None,
                                 };
                                 if let Some(pulses) = pulses_single.to_integer() {
-                                    if let Some(steps) = steps_single.to_integer(){
+                                    if let Some(steps) = steps_single.to_integer() {
                                         let out = Cycle::output(&mut b.left, rng);
-                                        for pulse in Cycle::bjorklund_pattern(pulses, steps, rotation) {
+                                        for pulse in
+                                            Cycle::bjorklund_pattern(pulses, steps, rotation)
+                                        {
                                             if pulse {
                                                 events.push(out.clone())
-                                            }else{
+                                            } else {
                                                 events.push(Events::empty())
                                             }
                                         }
                                     }
                                 }
                             }
-                            _ => () // TODO support something other than Step::Single as steps
+                            _ => (), // TODO support something other than Step::Single as steps
                         }
                     }
-                    _ => () // TODO support something other than Step::Single as pulses
+                    _ => (), // TODO support something other than Step::Single as pulses
                 }
                 Events::subdivide_lengths(&mut events);
                 Events::Multi(MultiEvents {
@@ -948,8 +928,7 @@ impl Cycle {
                     length: 1.0,
                     events,
                 })
-            }
-            // _ => Events::Single(SingleEvent::default())
+            } // _ => Events::Single(SingleEvent::default())
         }
     }
 
@@ -986,7 +965,7 @@ impl Cycle {
 
     // parse the root pair of the pest AST into a Subdivision
     // then update the spans of all the generated steps
-    fn generate(cycle: &mut Cycle) -> Vec<Vec<SingleEvent>>{
+    fn generate(cycle: &mut Cycle) -> Vec<Vec<SingleEvent>> {
         let mut events = Cycle::output(&mut cycle.root, &mut cycle.rng);
         Cycle::transform_spans(&mut events, &Span::default());
         // println!("{:#?}", events);
@@ -1004,15 +983,12 @@ impl Cycle {
                     let root = Cycle::parse_step(mini)?;
                     let seed = seed.unwrap_or_else(|| thread_rng().gen());
                     let rng = Xoshiro256PlusPlus::from_seed(seed);
-                    Ok(Self {
-                        root,
-                        rng,
-                    })
-                }else{
+                    Ok(Self { root, rng })
+                } else {
                     Err("couldn't parse input".to_string())
                 }
             }
-            Err(err) => Err(format!("{}", err))
+            Err(err) => Err(format!("{}", err)),
         }
     }
 
@@ -1054,10 +1030,9 @@ impl Cycle {
     }
 
     // TODO impl Display for Cycle
-    fn print(&mut self){
+    fn print(&mut self) {
         Cycle::crawl(&mut self.root, Cycle::print_steps, 0);
     }
-    
 }
 
 #[derive(Clone)]
@@ -1069,7 +1044,7 @@ struct State {
 mod test {
     use super::*;
 
-    fn parse_with_debug(input: &str){
+    fn parse_with_debug(input: &str) {
         println!("\n{}", "=".repeat(42));
         println!("\nINPUT\n {:?}", input);
         match Cycle::from(input, None) {
@@ -1099,15 +1074,13 @@ mod test {
                             i += 1
                         }
                         ci += 1
-
                     }
                     // cycle.reset();
                 }
             }
-            Err(err) => println!("{}", err)
+            Err(err) => println!("{}", err),
         }
     }
-
 
     #[test]
     pub fn test_tidal() {

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -21,12 +21,12 @@ struct State {
 
 #[derive(Clone, Debug)]
 struct Pitch {
-    note: i16,
+    note: u8,
     octave: u8,
 }
 
 impl Pitch {
-    fn as_note_value(note: char) -> Option<i16> {
+    fn as_note_value(note: char) -> Option<u8> {
         match note {
             'c' => Some(0),
             'd' => Some(2),
@@ -41,9 +41,10 @@ impl Pitch {
 
     fn parse(pair: Pair<Rule>) -> Pitch {
         let mut pitch = Pitch {
-            note: 60,
+            note: 0,
             octave: 4,
         };
+        let mut mark: i8 = 0;
         for p in pair.into_inner() {
             match p.as_rule() {
                 Rule::note => {
@@ -53,15 +54,28 @@ impl Pitch {
                 }
                 Rule::octave => pitch.octave = p.as_str().parse::<u8>().unwrap_or(pitch.octave),
                 Rule::mark => match p.as_str() {
-                    "#" => pitch.note += 1,
-                    "b" => pitch.note -= 1,
+                    "#" => mark = 1,
+                    "b" => mark = -1,
                     _ => (),
                 },
                 _ => (),
             }
         }
         // maybe an error should be thrown instead of a silent clamp
-        pitch.note = pitch.note.clamp(0, 127);
+        if pitch.note == 0 && mark == -1 {
+            if pitch.octave > 0 {
+                pitch.octave -= 1;
+                pitch.note = (11 as u8);
+            }
+        }else if pitch.note == 11 && mark == 1{
+            if pitch.octave < 10 {
+                pitch.note = 0;
+                pitch.octave += 1;
+            }
+        }else{
+            pitch.note = ((pitch.note as i8) + mark) as u8;
+        }
+        // pitch.note = pitch.note.clamp(0, 127);
         pitch
     }
 

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -1078,6 +1078,7 @@ impl Cycle {
     fn is_stateful(&self) -> bool {
         ['<', '{', '|', '?'].iter().any(|&c| self.input.contains(c))
     }
+
     fn from(input: &str, seed: Option<[u8; 32]>) -> Result<Self, String> {
         match Cycle::parse(Rule::mini, input) {
             Ok(mut tree) => {
@@ -1157,44 +1158,6 @@ struct State {
 mod test {
     use super::*;
 
-    // fn parse_with_debug(input: &str) {
-    //     println!("\n{}", "=".repeat(42));
-    //     println!("\nINPUT\n {:?}", input);
-    //     match Cycle::from(input, None) {
-    //         Ok(mut cycle) => {
-    //             // println!("\nCYCLE");
-    //             // cycle.print();
-
-    //             let stateful_chars = ['<', '{', '|', '?'];
-    //             let repeats = if stateful_chars.iter().any(|&c| input.contains(c)) {
-    //                 5
-    //             } else {
-    //                 1
-    //             };
-    //             println!("\nOUTPUT");
-    //             for i in 0..repeats {
-    //             //     println!(" {}", i);
-    //                 let mut channels = cycle.generate();
-    //             //     let mut ci = 0;
-    //             //     let channel_count = channels.len();
-    //             //     for channel in &mut channels {
-    //             //         if channel_count > 1 {
-    //             //             println!(" /{}", ci);
-    //             //         }
-    //             //         let mut i = 0;
-    //             //         for event in channel {
-    //             //             println!("  │{:02}│ {}", i, event);
-    //             //             i += 1
-    //             //         }
-    //             //         ci += 1
-    //             //     }
-    //             //     // cycle.reset();
-    //             }
-    //         }
-    //         Err(err) => println!("{}", err),
-    //     }
-    // }
-
     fn assert_cycles(input: &str, outputs: Vec<Vec<Vec<Event>>>) -> Result<(), String> {
         let mut cycle = Cycle::from(input, None)?;
         for out in outputs {
@@ -1206,9 +1169,6 @@ mod test {
     #[test]
 
     pub fn test_tidal() -> Result<(), String> {
-        // let file = fs::read_to_string("rhythm/test.tidal").expect("file not found");
-        // let line = file.lines().next().expect("no lines in file");
-        // println!("\nInput:\n{:?}\n", line);
         assert_eq!(
             Cycle::from("a b c d", None)?.generate(),
             [[
@@ -1527,10 +1487,7 @@ mod test {
             ],
         )?;
 
-        // let test = Cycle::from("1 ~ ~ 2 3 _ ~ _", None)?.generate();
-        // println!("{:#?}", Events::merge(&test));
-
-        // TODO test random output // parse_with_debug("[a b c d]?0.5");
+        // TODO test random outputs // parse_with_debug("[a b c d]?0.5");
 
         assert!(Cycle::from("a b c [d", None).is_err());
         assert!(Cycle::from("a b/ c [d", None).is_err());

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -9,7 +9,7 @@ use rand_xoshiro::Xoshiro256PlusPlus;
 // use pest::Token::Start;
 // use pest::error::ErrorVariant;
 
-use fraction;
+use fraction::{Fraction, Zero, One};
 type F = fraction::Fraction;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -250,8 +250,8 @@ impl Value {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct Span {
-    start: F,
-    end: F,
+    start: Fraction,
+    end: Fraction,
 }
 
 // convert a std rust range into a a Span
@@ -273,16 +273,16 @@ impl Span {
             end: start + outer.length() * self.length(),
         }
     }
-    fn length(&self) -> F {
+    fn length(&self) -> Fraction {
         self.end - self.start
     }
     fn default() -> Self {
         Span {
-            start: F::from(0),
-            end: F::from(1),
+            start: Fraction::zero(),
+            end: Fraction::one(),
         }
     }
-    fn new(start: F, end: F) -> Self {
+    fn new(start: Fraction, end: Fraction) -> Self {
         Self { start, end }
     }
 }
@@ -352,14 +352,14 @@ impl Display for CycleEvent {
 
 #[derive(Debug, Clone)]
 struct MultiEvents {
-    length: F,
+    length: Fraction,
     span: Span,
     events: Vec<Events>,
 }
 
 #[derive(Debug, Clone)]
 struct PolyEvents {
-    length: F,
+    length: Fraction,
     span: Span,
     channels: Vec<Events>,
 }
@@ -374,7 +374,7 @@ enum Events {
 impl Events {
     fn empty() -> Events {
         Events::Single(CycleEvent {
-            length: F::from(1),
+            length: Fraction::one(),
             span: Span::default(),
             value: Value::Rest,
             target: Target::None,
@@ -382,7 +382,7 @@ impl Events {
     }
     // only applied for Subdivision and Polymeter groups
     fn subdivide_lengths(events: &mut Vec<Events>) {
-        let mut length = F::from(0);
+        let mut length = Fraction::zero();
         for e in &mut *events {
             match e {
                 Events::Single(s) => length += s.length,
@@ -390,8 +390,8 @@ impl Events {
                 Events::Poly(p) => length += p.length,
             }
         }
-        let step_size = F::from(1) / length;
-        let mut start = F::from(0);
+        let step_size = Fraction::one() / length;
+        let mut start = Fraction::zero();
         for e in &mut *events {
             match e {
                 Events::Single(s) => {
@@ -772,7 +772,7 @@ impl Cycle {
     fn output(step: &mut Step, rng: &mut Xoshiro256PlusPlus) -> Events {
         match step {
             Step::Single(s) => Events::Single(CycleEvent {
-                length: F::from(1),
+                length: Fraction::one(),
                 target: Target::None,
                 span: Span::default(),
                 value: s.value.clone(),
@@ -791,7 +791,7 @@ impl Cycle {
                     Events::subdivide_lengths(&mut events);
                     Events::Multi(MultiEvents {
                         span: Span::default(),
-                        length: F::from(1),
+                        length: Fraction::one(),
                         events,
                     })
                 }
@@ -832,7 +832,7 @@ impl Cycle {
                     Events::subdivide_lengths(&mut events);
                     Events::Multi(MultiEvents {
                         span: Span::default(),
-                        length: F::from(1),
+                        length: Fraction::one(),
                         events,
                     })
                 }
@@ -847,7 +847,7 @@ impl Cycle {
                     }
                     Events::Poly(PolyEvents {
                         span: Span::default(),
-                        length: F::from(1),
+                        length: Fraction::one(),
                         channels,
                     })
                 }
@@ -869,7 +869,7 @@ impl Cycle {
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
                             span: Span::default(),
-                            length: F::from(1),
+                            length: Fraction::one(),
                             events,
                         })
                     }
@@ -959,7 +959,7 @@ impl Cycle {
                 Events::subdivide_lengths(&mut events);
                 Events::Multi(MultiEvents {
                     span: Span::default(),
-                    length: F::from(1),
+                    length: Fraction::one(),
                     events,
                 })
             } // _ => Events::Single(SingleEvent::default())

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -302,7 +302,7 @@ fn as_step(pair: Pair<Rule>) -> Result<Step, &str> {
                     }
                 }
             } else {
-                Err("empty alternating")
+                Ok(Step::Single(Single::default()))
             }
         }
         Rule::subdivision | Rule::mini => {
@@ -318,17 +318,18 @@ fn as_step(pair: Pair<Rule>) -> Result<Step, &str> {
                     }
                 }
             } else {
-                Err("empty subdivision")
+                Ok(Step::Single(Single::default()))
             }
         }
         Rule::polymeter => {
             if let Some(first) = pair.clone().into_inner().next() {
                 match first.as_rule() {
                     Rule::stack => Ok(Step::Stack(as_stack(first, pair))),
+                    Rule::polymeter_tail => Ok(Step::Single(Single::default())),
                     _ => as_polymeter(pair),
                 }
             } else {
-                Err("empty polymeter")
+                Ok(Step::Single(Single::default()))
             }
         }
         Rule::stack | Rule::section => {
@@ -670,5 +671,6 @@ mod test {
         parse_with_debug("{a b c d e}%3");
         parse_with_debug("{a b , c d e f g}%3");
         parse_with_debug("{a b <c d e f> [g a]}%3");
+        parse_with_debug("[1 2 ~] {}%42 [] <>");
     }
 }

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -488,10 +488,7 @@ fn output(step: &mut Step, state: State) -> Events {
     match step {
         Step::Single(s) => {
             Events::Single(SingleEvent {
-                length: match s.value {
-                    StepValue::Hold => 2.0,
-                    _ => 1.0
-                },
+                length: 1.0,
                 span: Span::default(),
                 value: s.value.clone(),
             })

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -65,7 +65,7 @@ impl Pitch {
         if pitch.note == 0 && mark == -1 {
             if pitch.octave > 0 {
                 pitch.octave -= 1;
-                pitch.note = (11 as u8);
+                pitch.note = 11 as u8;
             }
         }else if pitch.note == 11 && mark == 1{
             if pitch.octave < 10 {
@@ -123,7 +123,7 @@ impl Single {
             StepValue::Name(n) => Target::Name(n.clone()),
             StepValue::Integer(i) => Target::Index(*i),
             StepValue::Float(f) => Target::Index(*f as i32),
-            StepValue::Pitch(n) => Target::Name(self.string.clone()), // TODO might not be the best conversion idea
+            StepValue::Pitch(_n) => Target::Name(self.string.clone()), // TODO might not be the best conversion idea
         }
     }
     fn to_chance(&self) -> Option<f64> {
@@ -369,7 +369,7 @@ impl Events {
             }
         }
     }
-    fn mutate_events<F>(&mut self, mut fun: &mut F)
+    fn mutate_events<F>(&mut self, fun: &mut F)
     where
         F: FnMut(&mut SingleEvent),
     {
@@ -756,7 +756,7 @@ fn output(step: &mut Step, state: State) -> Events {
                     match e.right.as_ref() {
                         Step::Single(s) => {
                             if let Some(mult) = s.to_integer(){
-                                for i in 0..mult{
+                                for _i in 0..mult{
                                     events.push(output(&mut e.left, state.clone()))
                                 }
                             }
@@ -931,7 +931,7 @@ fn reset_step(step: &mut Step, _level: usize) {
 // parse the root pair of the pest AST into a Subdivision
 // then update the spans of all the generated steps
 fn parse_tree(tree: &Pair<Rule>) -> Result<Step, String> {
-    let mut cycle = parse_step(tree.clone())?;
+    let cycle = parse_step(tree.clone())?;
     // update_span(&mut cycle, &Span::default());
     Ok(cycle)
 }
@@ -968,7 +968,7 @@ mod test {
             Step::Choices(cs) => format!("{} |{}|", "Choices", cs.choices.len()),
             Step::Stack(st) => format!("{} ({})", "Stack", st.stack.len()),
             Step::Expression(e) => format!("Expression {:?}", e.operator),
-            Step::Bjorklund(b) => format!("Bjorklund {}", ""),
+            Step::Bjorklund(_b) => format!("Bjorklund {}", ""),
         };
         println!("{} {}", indent_lines(level), name);
     }

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -908,6 +908,7 @@ impl Cycle {
                 match e.operator {
                     Operator::Fast() => {
                         let mut events = vec![];
+                         #[allow(clippy::single_match)] // TODO support something other than Step::Single as the right hand side
                         match e.right.as_ref() {
                             Step::Single(s) => {
                                 if let Some(mult) = s.to_integer() {
@@ -916,7 +917,7 @@ impl Cycle {
                                     }
                                 }
                             }
-                            _ => (), // TODO support something other than Step::Single as the right hand side
+                            _ => (), 
                         }
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
@@ -927,14 +928,16 @@ impl Cycle {
                     }
                     Operator::Target() => {
                         let mut out = Cycle::output(e.left.as_mut(), rng);
+                         #[allow(clippy::single_match)] // TODO support something other than Step::Single as the right hand side
                         match e.right.as_ref() {
                             Step::Single(s) => out.mutate_events(&mut |e| e.target = s.to_target()),
-                            _ => (), // TODO support something other than Step::Single as the right hand side
+                            _ => (),
                         }
                         out
                     }
                     Operator::Degrade() => {
                         let mut out = Cycle::output(e.left.as_mut(), rng);
+                         #[allow(clippy::single_match)] // TODO support something other than Step::Single as the right hand side
                         match e.right.as_ref() {
                             Step::Single(s) => out.mutate_events(&mut |e: &mut Event| {
                                 if let Some(chance) = s.to_chance() {
@@ -943,13 +946,14 @@ impl Cycle {
                                     }
                                 }
                             }),
-                            _ => (), // TODO support something other than Step::Single as the right hand side
+                            _ => (),
                         }
                         out
                     }
                     Operator::Replicate() => {
                         let mut events = vec![];
                         let mut length = Fraction::from(1);
+                         #[allow(clippy::single_match)] // TODO support something other than Step::Single as the right hand side
                         match e.right.as_ref() {
                             Step::Single(s) => {
                                 if let Some(mult) = s.to_integer() {
@@ -960,7 +964,7 @@ impl Cycle {
                                     }
                                 }
                             }
-                            _ => (), // TODO support something other than Step::Single as the right hand side
+                            _ => (),
                         }
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
@@ -973,6 +977,7 @@ impl Cycle {
             }
             Step::Bjorklund(b) => {
                 let mut events = vec![];
+                #[allow(clippy::single_match)] // TODO support something other than Step::Single as the right hand side
                 match b.pulses.as_ref() {
                     Step::Single(pulses_single) => {
                         match b.steps.as_ref() {

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -458,6 +458,7 @@ impl Events {
 #[grammar = "rhythm/tidal.pest"]
 pub struct Cycle {
     root: Step,
+    iteration: u32,
     rng: Xoshiro256PlusPlus,
 }
 
@@ -994,6 +995,7 @@ impl Cycle {
 
     // reset all the stateful steps like Alternating and Polymeter to their starting state
     fn reset(&mut self) {
+        self.iteration = 0;
         Cycle::crawl(&mut self.root, Cycle::reset_step, 0)
     }
 
@@ -1005,8 +1007,8 @@ impl Cycle {
         let mut channels = vec![];
         events.flatten(&mut channels, 0);
 
-        // TODO comment this out, it's just for test debugging
-        println!("\n{}", "OUTPUT");
+        // this is just for test debugging
+        println!("\n{} {}", "OUTPUT", self.iteration);
         let mut ci = 0;
         let channel_count = channels.len();
         for channel in &mut channels {
@@ -1021,6 +1023,7 @@ impl Cycle {
             ci += 1
         }
 
+        self.iteration += 1;
         channels
     }
 
@@ -1033,7 +1036,8 @@ impl Cycle {
                     let root = Cycle::parse_step(mini)?;
                     let seed = seed.unwrap_or_else(|| thread_rng().gen());
                     let rng = Xoshiro256PlusPlus::from_seed(seed);
-                    let mut cycle = Self { root, rng };
+                    let iteration = 0;
+                    let mut cycle = Self { root, rng, iteration };
                     println!("\nCYCLE");
                     cycle.print();
                     Ok(cycle)

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 use rand::{thread_rng, Rng, SeedableRng};

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -824,7 +824,7 @@ impl Cycle {
 
                     for i in 0..pm.count {
                         events.push(Cycle::output(
-                            &mut pm.steps[(offset + i) % length].clone(),
+                            &mut pm.steps[(offset + i) % length],
                             rng,
                         ))
                     }
@@ -898,9 +898,11 @@ impl Cycle {
                     }
                     Operator::Replicate() => {
                         let mut events = vec![];
+                        let mut length = Fraction::from(1);
                         match e.right.as_ref() {
                             Step::Single(s) => {
                                 if let Some(mult) = s.to_integer() {
+                                    length = Fraction::from(mult);
                                     let out = Cycle::output(&mut e.left, rng);
                                     for _i in 0..mult {
                                         events.push(out.clone())
@@ -912,7 +914,7 @@ impl Cycle {
                         Events::subdivide_lengths(&mut events);
                         Events::Multi(MultiEvents {
                             span: Span::default(),
-                            length: F::from(1),
+                            length,
                             events,
                         })
                     }

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -24,17 +24,17 @@ struct Pitch {
     octave: u8,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 enum StepValue {
+    #[default] Rest,
+    Hold,
     Float(f64),
     Integer(i32),
     Pitch(Pitch),
     Name(String),
-    Rest,
-    Hold,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct Span {
     start: f64,
     end: f64,
@@ -53,9 +53,9 @@ impl Span {
         self.end - self.start
     }
     fn default() -> Self {
-        Span {
-            start: 0.0,
-            end: 0.0,
+        Span{
+            start : 0.0,
+            end : 1.0
         }
     }
 }
@@ -85,13 +85,24 @@ enum Step {
     Choices(Choices),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 struct Single {
     value: StepValue,
     // might not be necessary to have a span here since it's always 0->1 currently
     span: Span,
     target : Option<i16>, // value for instruments
     string: String,
+}
+
+impl Single {
+    fn default() -> Self {
+        Single {
+            value: StepValue::Rest,
+            span: Span::default(),
+            target: None,
+            string: String::from("~")
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use core::fmt::Display;
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 use rand::{thread_rng, Rng, SeedableRng};
@@ -65,14 +66,14 @@ struct CycleEvent {
     value: StepValue,
 }
 
-impl CycleEvent {
-    fn to_string(&self) -> String {
-        format!(
+impl Display for CycleEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
             "{:.3} -> {:.3} | {:?}",
             self.span.start, self.span.end, self.value
-        )
+        ))
     }
-}
+} 
 
 #[derive(Clone, Debug)]
 enum Step {
@@ -628,7 +629,8 @@ mod test {
                             println!(" {}", i);
                             output_events(&mut step, State { seed: None }, &Span::default())
                                 .iter()
-                                .for_each(|e| println!("  │ {}", e.to_string()));
+                                .enumerate()
+                                .for_each(|(i, e)| println!("  │{:02}│ {}", i, e));
                             // crawl_step(&mut step, reset_step, 0);
                         }
                     }

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -533,6 +533,7 @@ impl Events {
 pub struct Cycle {
     root: Step,
     iteration: u32,
+    input: String,
     rng: Xoshiro256PlusPlus,
 }
 
@@ -1100,6 +1101,9 @@ impl Cycle {
         channels
     }
 
+    fn is_stateful(&self) -> bool {
+        ['<', '{', '|', '?'].iter().any(|&c| self.input.contains(c))
+    }
     fn from(input: &str, seed: Option<[u8; 32]>) -> Result<Self, String> {
         match Cycle::parse(Rule::mini, input) {
             Ok(mut tree) => {
@@ -1114,6 +1118,7 @@ impl Cycle {
                         root,
                         rng,
                         iteration,
+                        input: input.to_string(),
                     };
                     println!("\nCYCLE");
                     cycle.print();

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -240,7 +240,7 @@ impl StepValue {
             Rule::rest => Ok(StepValue::Rest),
             Rule::pitch => Ok(StepValue::Pitch(Pitch::parse(pair))),
             Rule::name => Ok(StepValue::Name(pair.as_str().to_string())),
-            _ => Err(format!("unrecognized pair\n{:?}", pair)),
+            _ => Err(format!("unrecognized pair in single\n{:?}", pair)),
         }
     }
 }
@@ -561,7 +561,7 @@ impl Cycle {
                     })])
                 }
                 _ => {
-                    Err(format!("unexpected rule in section{:?}", inner))
+                    Err(format!("unexpected rule in section\n{:?}", inner))
                 }
             }
         } else {

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -1023,7 +1023,7 @@ mod test {
                     Ok(mut step) => {
                         println!("\nCYCLE");
                         crawl_step(&mut step, print_steps, 0);
-                        let stateful_chars = ['<', '{', '|'];
+                        let stateful_chars = ['<', '{', '|', '?'];
                         let repeats = if stateful_chars.iter().any(|&c| input.contains(c)) {
                             5
                         } else {
@@ -1085,7 +1085,12 @@ mod test {
         parse_with_debug("1 [2 [3 [4 [5 [6 [7 [8 [9 10]]]]]]]]");
         parse_with_debug("1 [2 <[3 4] <5 [6 7] [6 _ 7] [8 9 10]>>]");
         parse_with_debug("[1 2] [3 4, 5 6]");
-        // parse_with_debug("1 2, 3 4");
-        
+        parse_with_debug("a*2 b c");
+        parse_with_debug("a b c [d e]*4");
+        parse_with_debug("a:1 b:2 c:3 [d e f g]:4");
+        parse_with_debug("[a b c d]?0.5");
+        parse_with_debug("a b!2 c!3 d!4 [1 2 3 4]!5");
+        parse_with_debug("a(6,8)");
+        parse_with_debug("[a b](3,8)");
     }
 }

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -1,99 +1,691 @@
-//! PEST parser for tidal mini-notations, based on the Tidal-Cycles mini-notation. WIP!
-
-#[cfg(test)]
 use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
-
-// --------------------------------------------------------------------------------------------------
+use rand::{thread_rng, Rng, SeedableRng};
+use rand_xoshiro::Xoshiro256PlusPlus;
+// use std::fs;
+// use pest::iterators::Pairs;
+// use pest::Token::Start;
+// use pest::error::ErrorVariant;
 
 #[derive(Parser)]
 #[grammar = "rhythm/tidal.pest"]
-pub struct ExprParser;
+pub struct MiniParser;
 
-// --------------------------------------------------------------------------------------------------
+#[derive(Clone)]
+struct State {
+    seed : Option<[u8;32]>
+}
 
-#[cfg(test)]
-fn parse_mini(pair: Pair<Rule>, level: usize) {
+#[derive(Clone, Debug)]
+struct Pitch {
+    note : i16,
+    octave : u8,
+}
+
+#[derive(Clone, Debug)]
+enum StepValue {
+    Float(f64),
+    Integer(u32),
+    Pitch(Pitch),
+    Name(String),
+    Rest,
+    Hold,
+}
+
+#[derive(Clone, Debug)]
+struct Span {
+    start : f64,
+    end : f64,
+}
+
+impl Span {
+    fn length(&self) -> f64 {
+        self.end - self.start
+    }
+}
+
+#[derive(Debug)]
+struct CycleEvent {
+    span : Span,
+    value : StepValue,
+}
+
+
+impl CycleEvent {
+    fn to_string(&self) -> String {
+        format!("{:.3} -> {:.3} | {:?}", self.span.start, self.span.end, self.value)
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Step {
+    Single(Single),
+    Alternating(Alternating),
+    Subdivision(Subdivision),
+    Polymeter(Polymeter),
+    Stack(Stack),
+    Choices(Choices),
+}
+
+#[derive(Clone, Debug)]
+struct Single {
+    value : StepValue,
+    // might not be necessary to have a span here since it's always 0->1 currently
+    span : Span,
+    string : String,
+}
+
+#[derive(Clone, Debug)]
+struct Alternating {
+    current : usize,
+    span : Span,
+    steps : Vec<Step>,
+}
+
+
+#[derive(Clone, Debug)]
+struct Subdivision {
+    span : Span,
+    steps : Vec<Step>,
+}
+
+#[derive(Clone, Debug)]
+struct Polymeter {
+    count : usize,
+    offset : usize,
+    span : Span,
+    steps : Vec<Step>,
+}
+
+#[derive(Clone, Debug)]
+struct Choices {
+    span : Span,
+    choices : Vec<Step>,
+}
+
+#[derive(Clone, Debug)]
+struct Stack {
+    span : Span,
+    stack : Vec<Step>,
+}
+
+// recursively sets up the relative span of steps after the initial parsing
+fn update_span(step: &mut Step, span: &Span){
+    match step {
+        Step::Single(s) => {
+            s.span = span.clone()
+        }
+        Step::Alternating(a) => {
+            a.span = span.clone();
+            for s in &mut a.steps {
+                update_span(  s, span)
+            }
+        }
+        Step::Subdivision(sd) => {
+            sd.span = span.clone();
+            // let step_size = span.length() / (sd.steps.len() as f64);
+            let step_size = 1.0 / (sd.steps.len() as f64);
+            let mut time = 0.0;
+            for mut step in &mut sd.steps {
+                let sub = Span{start : time, end : time + step_size};
+                update_span(&mut step, &sub);
+                time += step_size
+            }
+        }
+        Step::Polymeter(pm) => {
+            pm.span = span.clone();
+            for s in &mut pm.steps {
+                update_span(s, span)
+            }
+        }
+        Step::Stack(st) => {
+            st.span = span.clone();
+            for s in &mut st.stack {
+                update_span(  s, span)
+            }
+        }
+        Step::Choices(cs) => {
+            cs.span = span.clone();
+            for s in &mut cs.choices {
+                update_span(s, span)
+            }
+        }
+    }
+}
+
+// transforms a nested relative span according to an absolute span at output time
+fn transform_span(inner : &Span, outer : &Span) -> Span {
+    let start = outer.start + outer.length() * inner.start;
+    Span {
+        start : start,
+        end : start + outer.length() * inner.length()
+    }
+}
+
+fn as_note_value(note : char) -> Option<i16> {
+    match note {
+        'c' => Some(0),
+        'd' => Some(2),
+        'e' => Some(4),
+        'f' => Some(5),
+        'g' => Some(7),
+        'a' => Some(9),
+        'b' => Some(11),
+        _ => None
+    }
+}
+
+fn as_pitch(pair : Pair<Rule>) -> Pitch{
+    let mut pitch = Pitch {
+        note : 60,
+        octave : 4,
+    };
+    for p in pair.into_inner() {
+        match p.as_rule() {
+            Rule::note => {
+                if let Some(c) = String::from(p.as_str()).to_ascii_lowercase().chars().next() {
+                    pitch.note = as_note_value(c).unwrap_or(pitch.note)
+                }
+            }
+            Rule::octave => {
+                pitch.octave = p.as_str().parse::<u8>().unwrap_or(pitch.octave)
+            }
+            Rule::mark => {
+                match p.as_str() {
+                    "#" => pitch.note += 1,
+                    "b" => pitch.note -= 1,
+                    _ => ()
+                }
+            }
+            _ => ()
+        }
+    }
+    // maybe an error should be thrown instead of a silent clamp
+    pitch.note = pitch.note.clamp(0, 127);
+    pitch
+}
+
+// recursively output events for the entire cycle based on some state (random seed)
+fn output_events(step : &mut Step, state: State, span:&Span) -> Vec<CycleEvent> {
+    // let mut override_span = span.clone();
+    // if let Some(sp) = override_span {
+    //     update_span(step, &sp);
+    //     override_span = None;
+    // }
+    match step {
+        Step::Single(s) => {
+            vec![CycleEvent {
+                span : transform_span(&s.span, span),
+                value : s.value.clone(),
+            }]
+        }
+        Step::Alternating(a) => {
+            if a.steps.len() == 0 { vec![] }
+            else{
+                let current = a.current % a.steps.len();
+                a.current += 1;
+                if let Some(step) = a.steps.get_mut(current){
+                    output_events(step, state, &transform_span(&a.span, span))
+                }else{
+                    vec![]
+                }
+            }
+        }
+        Step::Subdivision(sd) => {
+            if sd.steps.len() == 0 { vec![] }
+            else{
+                let mut events = vec![];
+                for s in &mut sd.steps {
+                    events.extend(output_events(s, state.clone(), &transform_span(&sd.span, span)))
+                }
+                events
+            }
+        }
+        Step::Polymeter(pm) => {
+            if pm.steps.len() == 0 { vec![] }
+            else{
+                let mut events = vec![];
+                let length = pm.steps.len();
+                let offset = pm.offset;
+                
+                let step_size = pm.span.length() / (pm.count as f64);
+                let mut time = pm.span.start;
+
+                pm.offset += pm.count;
+                for i in 0..pm.count{
+                    let start = time;
+                    let end = time + step_size;
+                    time = end;
+                    let sub = Span{start : start, end : end};
+                    events.extend(output_events(&mut pm.steps[(offset + i) % length].clone(), state.clone(), &transform_span(&sub, &pm.span)))
+                }
+                events
+            }
+        }
+        Step::Stack(st) => {
+            if st.stack.len() == 0 { vec![] }
+            else{
+                let mut events = vec![];
+                for s in &mut st.stack {
+                    events.extend(output_events(s, state.clone(), &transform_span(&st.span, span)))
+                }
+                events
+            }
+        }
+        Step::Choices(cs) => { 
+            // TODO move this outside
+            let seed = state.seed.unwrap_or_else(|| thread_rng().gen());
+            let mut rng = Xoshiro256PlusPlus::from_seed(seed);
+            let choice = rng.gen_range(0..cs.choices.len());
+            output_events(&mut cs.choices[choice], state, span)
+        }
+    }
+}
+
+// helper to create default span
+fn span() -> Span {
+    Span {
+        start : 0.0,
+        end : 1.0
+    }
+}
+
+// parse a single into a value
+fn as_value(pair: Pair<Rule>) -> StepValue {
+    // println!("{:?}", pair);
     match pair.as_rule() {
-        // container
-        Rule::mini => {
-            debug_assert!(level == 0);
-            println!("mini: {}", pair.as_str());
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
+        Rule::number => {
+            if let Some(n) = pair.into_inner().next() {
+                match n.as_rule() {
+                    Rule::integer => 
+                        StepValue::Integer(n.as_str().parse::<u32>().unwrap_or(0)),
+                    Rule::float =>
+                        StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)),
+                    Rule::normal =>
+                        StepValue::Float(n.as_str().parse::<f64>().unwrap_or(0.0)),
+                    _ => unreachable!()
+                }
+            }else{
+                unreachable!()
             }
         }
-
-        // sequences
-        Rule::polymeter => {
-            println!("{} polymeter:", "\t".repeat(level));
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
-            }
+        Rule::hold => {
+            StepValue::Hold
         }
-        Rule::sub_cycle => {
-            println!("{} sub_cycle:", "\t".repeat(level));
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
-            }
+        Rule::rest => {
+            StepValue::Rest
         }
-
-        Rule::stack_tail => {
-            println!("{} stack_tail:", "\t".repeat(level));
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
-            }
+        Rule::pitch => {
+            StepValue::Pitch(as_pitch(pair))
         }
-        Rule::choose_tail => {
-            println!("{} choose_tail:", "\t".repeat(level));
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
-            }
+        Rule::name => {
+            StepValue::Name(pair.as_str().to_string())
         }
-        Rule::dot_tail => {
-            println!("{} dot_tail:", "\t".repeat(level));
-            for item in pair.into_inner() {
-                parse_mini(item, level + 1);
-            }
-        }
-
-        // atomic expressions
-        Rule::op_bjorklund => println!("{} bjorklund: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_replicate => println!("{} op_replicate: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_weight => println!("{} op_weight: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_slow => println!("{} op_slow: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_fast => println!("{} op_fast: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_degrade => println!("{} op_degrade: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_tail => println!("{} op_tail: {:?}", "\t".repeat(level), pair.as_str()),
-        Rule::op_range => println!("{} op_range: {:?}", "\t".repeat(level), pair.as_str()),
-
-        Rule::step => println!("{} step: {:?}", "\t".repeat(level), pair.as_str()),
-
-        Rule::EOI => {}
         _ => unreachable!()
     }
 }
 
-#[cfg(test)]
-fn parse(input: &str) {
-    let mut parsed = ExprParser::parse(Rule::mini, input).unwrap();
-    let level = 0;
-    parse_mini(parsed.next().unwrap(), level);
+// stacks can only appear inside groups like Subdivision, Alternating or Polymeter
+// they will have a stack of steps with their parent's type inside
+fn as_stack(pair : Pair<Rule>, parent: Pair<Rule>) -> Stack {
+
+    let mut stack = Stack {
+        span : span(),
+        stack : vec![],
+    };
+    match parent.as_rule() {
+        Rule::alternating => {
+            for p in pair.into_inner(){
+                stack.stack.push(Step::Alternating(Alternating{
+                    span : span(),
+                    current : 0,
+                    steps : section_as_steps(p)
+                }))
+            }
+        }
+        Rule::subdivision => {
+            for p in pair.clone().into_inner(){
+                stack.stack.push(Step::Subdivision(Subdivision{
+                    span : span(),
+                    steps : section_as_steps(p)
+                }))
+            }
+        }
+        Rule::polymeter => {
+            if let Some(count) = as_polymeter_count(&parent) {
+                for p in pair.clone().into_inner(){
+                    stack.stack.push(Step::Polymeter(Polymeter{
+                        count : count,
+                        offset : 0,
+                        span : span(),
+                        steps : section_as_steps(p)
+                    }))
+                }
+            }
+        }
+        _ => ()
+    }
+    stack
 }
 
-// --------------------------------------------------------------------------------------------------
+fn as_polymeter_count(pair: &Pair<Rule>) -> Option<usize>{
+    for p in pair.clone().into_inner() {
+        match p.as_rule() {
+            Rule::polymeter_tail => { // TODO a more generic parameter here
+                if let Some(count) = p.into_inner().next(){
+                    return Some(count.as_str().parse::<usize>().unwrap_or(1))
+                }
+            }
+            _ => ()
+        }
+    }
+    None
+}
+
+fn as_polymeter(pair : Pair<Rule>) -> Result<Step, &str>{
+    if let Some(count) = as_polymeter_count(&pair) {
+        let mut inner = pair.clone().into_inner();
+        if let Some(poly_list) = inner.next(){
+            return Ok(Step::Polymeter(Polymeter{
+                count : count,
+                offset : 0,
+                span : span(),
+                steps : section_as_steps(poly_list)
+            }))
+        }
+    }
+    Err("invalid polymeter")
+}
+
+// recursively parse a pair as a Step
+fn as_step(pair : Pair<Rule>) -> Result<Step, &str> {
+    match pair.as_rule() {
+        Rule::single => {
+            if let Some(v) = pair.into_inner().next(){
+                Ok(Step::Single(Single{
+                    span : span(),
+                    string : v.as_str().to_string(),
+                    value : as_value(v),
+                }))
+            }else{
+                unreachable!()
+            }
+        }
+        Rule::alternating => {
+            if let Some(first) = pair.clone().into_inner().next() {
+                match first.as_rule() {
+                    Rule::stack => {
+                        Ok(Step::Stack(as_stack(first, pair)))
+                    }
+                    _ => {
+                        let a = Alternating {
+                            span : span(),
+                            current : 0,
+                            steps : unwrap_section(pair),
+                        };
+                        Ok(Step::Alternating(a))
+                    }
+                }
+            }else{
+                Err("empty alternating")
+            }
+        }
+        Rule::subdivision | Rule::mini => {
+            if let Some(first) = pair.clone().into_inner().next() {
+                match first.as_rule() {
+                    Rule::stack => {
+                        Ok(Step::Stack(as_stack(first, pair)))
+                    }
+                    _ => {
+                        let sd = Subdivision {
+                            span : span(),
+                            steps : unwrap_section(pair),
+                        };
+                        Ok(Step::Subdivision(sd))
+                    }
+                }
+            }else{
+                Err("empty subdivision")
+            }
+        }
+        Rule::polymeter => {
+            if let Some(first) = pair.clone().into_inner().next() {
+                match first.as_rule() {
+                    Rule::stack => {
+                        Ok(Step::Stack(as_stack(first, pair)))
+                    }
+                    _ => {
+                        as_polymeter(pair)
+                    }
+                }
+            }else{
+                Err("empty polymeter")
+            }
+        }
+        Rule::stack => {
+            // stacks can only appear inside rules for Subdivision, Alternating or Polymeter
+            Err("internal error, unexpected branch reached")
+        }
+        Rule::section => {
+            // sections are always immediately handled within other rules
+            // using unwrap_section or section_as_steps
+            Err("aa")
+        }
+        Rule::choices => {
+            Err("sas")
+        }
+        _ => Err("type not implemented")
+    }
+}
+
+// helper to convert a section rule to a vector of Steps
+fn section_as_steps(pair : Pair<Rule>) -> Vec<Step>{
+    let mut steps = vec![];
+    for pair in pair.into_inner() {
+        match as_step(pair) {
+            Ok(s) => steps.push(s),
+            Err(s) => println!("{:?}", s)
+        }
+    }
+    steps
+}
+
+// helper to convert a section or single to a vector of Steps
+fn unwrap_section(pair : Pair<Rule>) -> Vec<Step> {
+    if let Some(inner) = pair.into_inner().next(){
+        match inner.as_rule() {
+            Rule::single => {
+                if let Ok(s) = as_step(inner) {
+                    vec![s]
+                }else{
+                    vec![]
+                }
+            }
+            Rule::section => {
+                section_as_steps(inner)
+            }
+            Rule::choices => {
+                let mut choices : Vec<Step> = vec![];
+                for p in inner.into_inner() {
+                    if let Some(step) = p.into_inner().next(){
+                        if let Ok(choice) = as_step(step) {
+                            choices.push(choice)
+                        }
+                    }                    
+                }
+                vec![Step::Choices(Choices{
+                    span : span(),
+                    choices
+                })]
+            }
+            _ => {
+                println!("{:?}", inner);
+                unreachable!()
+            }
+        }
+    }else{
+        vec![]
+    }
+}
+
+fn crawl_step(step: &mut Step, fun :  fn(&mut Step, usize), level : usize){
+    fun(step, level);
+    match step {
+        Step::Single(_s) => (),
+        Step::Alternating(a) => for s in &mut a.steps {
+            crawl_step(s, fun, level + 1)
+        }
+        Step::Polymeter(pm) => for s in &mut pm.steps {
+            crawl_step(s,fun, level + 1)
+        }
+        Step::Subdivision(sd) => for s in &mut sd.steps {
+            crawl_step(s,fun, level + 1)
+        }
+        Step::Choices(cs) => for s in &mut cs.choices {
+            crawl_step(s,fun, level + 1)
+        }
+        Step::Stack(st)  => for s in &mut st.stack {
+            crawl_step(s, fun, level + 1)
+        }
+    }
+}
+
+fn reset_step(step: &mut Step, _level: usize) {
+    match step {
+        Step::Alternating(a) => {
+            a.current = 0;
+        }
+        Step::Polymeter(pm) => {
+            pm.offset = 0;
+        }
+        _ => ()
+    }
+}
+
+// parse the root pair of the pest AST into a Subdivision
+// then update the spans of all the generated steps
+fn parse_tree(tree: &Pair<Rule>) -> Result<Step, String>{
+    let mut cycle = as_step(tree.clone())?;
+    update_span(&mut cycle, &span());
+    Ok(cycle)
+}
+
+// parse a string into a step
+fn parse(input : &str) -> Result<Step, String> {
+    match MiniParser::parse(Rule::mini, &input) {
+        Ok(mut tree) => parse_tree(&tree.next().unwrap()),
+        Err(err) => Err(format!("{}", err))
+    }
+    
+    // let parse_result = MiniParser::parse(Rule::mini, &input);
+    // match parse_result {
+    //     Ok(mut ast) => {
+    //         let mini = ast.next().unwrap();
+    //         println!("\nTREE");
+    //         print_pairs(&mini, 0);
+    //         parse_ast(&mini)
+    //     }
+    //     Err(err) => Err(format!("{}", err))
+    //         // match err.variant {
+    //         // ErrorVariant::ParsingError { .. } => Err(format!("{}", err)),
+    // }
+}
+
+
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    fn indent_lines(level : usize) -> String {
+        let mut lines = String::new();
+        for i in 0..level {
+            lines += [" │", " |"][i % 2];
+        }
+        lines
+    }
+
+    fn print_steps(step: &mut Step, level: usize) {
+        let name = match step {
+            Step::Single(s) => match &s.value {
+                StepValue::Pitch(_p) => format!("{:?} {}", s.value,  s.string),
+                _ => format!("{:?} {:?}", s.value,  s.string)
+            }
+            Step::Subdivision(sd) => format!("{} [{}]","Subdivision", sd.steps.len()),
+            Step::Alternating(a) => format!("{} <{}>","Alternating", a.steps.len()),
+            Step::Polymeter(pm) => format!("{} {{{}}}","Polymeter", pm.steps.len()),
+            Step::Choices(cs) => format!("{} |{}|","Choices", cs.choices.len()),
+            Step::Stack(st)  => format!("{} ({})","Stack", st.stack.len()),
+        };
+        println!("{} {}", indent_lines(level), name);
+    }
+
+    fn print_pairs(pair:&Pair<Rule>, level : usize){
+        println!("{} {:?} {:?}", indent_lines(level), pair.as_rule(),pair.as_str());
+        for p in pair.clone().into_inner() {
+            print_pairs(&p, level + 1)
+        }
+    }
+
+    fn parse_with_debug(input : &str){        
+        println!("\n{}", "=".repeat(42));
+        println!("\nINPUT\n {:?}\n", input);
+        match MiniParser::parse(Rule::mini,&input) {
+            Ok(mut tree) => {
+                let mini = tree.next().unwrap();
+                print_pairs(&mini, 0);
+                match parse_tree(&mini) {
+                    Ok(mut step) => {
+                        println!("\nCYCLE");
+                        crawl_step(&mut step, print_steps, 0);
+                        let stateful_chars = ['<', '{', '|'];
+                        let repeats = if stateful_chars.iter().any(|&c| input.contains(c)){4}else{1};
+                        println!("\nOUTPUT");
+                        for i in 0..repeats{
+                            println!(" {}", i);
+                            output_events(&mut step, State{seed : None}, &span()).iter().for_each(|e| println!("  │ {}", e.to_string()));                
+                        }
+
+                        // crawl_step(&mut step, reset_step, 0);
+                        // for i in 0..3{
+                        //     println!(" {}", i);
+                        //     output_events(&mut step, State{seed : None}, &span()).iter().for_each(|e| println!("  │ {}", e.to_string()));                
+                        // }
+                    },
+                    Err(s) => println!("{}", s)
+                }
+            }
+            Err(err) => println!("{}", err)
+        }
+    }
+
     #[test]
-    fn test_tidal() {
-        parse("a b c");
-        parse("[a b] c");
-        parse("a|b c");
-        parse("a _ b _");
-        parse("a(2, 8) b c");
-        parse("a {b c, d e, f} e");
+    pub fn test_tidal() {
+        // let file = fs::read_to_string("rhythm/test.tidal").expect("file not found");
+        // let line = file.lines().next().expect("no lines in file");
+        // println!("\nInput:\n{:?}\n", line);
+
+        parse_with_debug("a b c d");
+        parse_with_debug("a b [c d]");
+        parse_with_debug("[a a] [b b b] [c d c d]");
+        parse_with_debug("[a [b [c d]]] e [[[f g] a ] b]");
+        parse_with_debug("[a [b [c d]]] , [[[f g] a ] b]");
+        parse_with_debug("a b <c d>");
+        parse_with_debug("<a b , <c d>>");
+        parse_with_debug("<a <b c d> e <f <a b c d>> <g a b>>");
+        parse_with_debug("{a b c d e}%4");
+        parse_with_debug("{a b c d e}%3");
+        parse_with_debug("{a b , c d e f g}%3");
+        parse_with_debug("{a b <c d e f> [g a]}%3");
     }
 }
+
+/*
+    TODO
+        proper error handling
+        operators
+        output
+            apply rest and hold
+            rework and sort stacks
+            convert to shared types
+ */

--- a/src/rhythm/tidal.rs
+++ b/src/rhythm/tidal.rs
@@ -332,6 +332,25 @@ impl CycleEvent {
         self.value = Value::Pitch(Pitch{ note, octave });
         self.clone()
     }
+
+    fn int(&mut self, i: i32) -> Self {
+        self.value = Value::Integer(i);
+        self.clone()
+    }
+    fn name(&mut self, n: &str) -> Self{
+        self.value = Value::Name(n.to_string());
+        self.clone()
+    }
+    fn hold(&mut self) -> Self {
+        self.value = Value::Hold;
+        self.clone()
+    }
+
+    fn float(&mut self, f: f64) -> Self {
+        self.value = Value::Float(f);
+        self.clone()
+    }
+
     fn target(&mut self, target: Target) -> Self {
         self.target = target;
         self.clone()


### PR DESCRIPTION
Here is the first draft. Please excuse my rust, I'm sure I am not using the proper rust idioms, features and what-not, any hints would be welcome.

I've implemented the basics of the mini notation (excluding any operators for now) by building an intermediate recursive structure `Step`. The pest AST is converted into this form then `output_events` can generate a flat list of events with start and end times. 

```bash
cargo test --lib -- --exact rhythm::tidal::test::test_tidal --show-output
```
This will run the test and print the AST, the parsed structure and output events for a bunch of test strings. 

Step literals are parsed as they should be
* `Integer`s as expected `3`, `5`, `8`, `-13`
* `Float`s can be typed as `1.0`, `.5` or `1.`
* `Pitch` is parsed from case-insensitive notes from `abcdefg` with an optional sharp/flat mark and octave like `a#3` or `Ab4`
* arbitrary string identifiers like `kick`, `lick` or whatever, turn into `Name`
*  `~` as `Rest`
* `_` as `Hold`

Pattern groupings are mostly working, including nested structures
* `[ ]` as `Subdivision` (which is what the root step of any cycle is as well)
* `< >` as `Alternating`, these keep their state as `current` index
* `{ }%N` as `Polymeter` with inner state `offset`. The variant in Tidal without `%N` parameter is not supported, I think that is kind of confusing anyway since you have to remember which side wraps the other and it won't do anything without an inner `,`
* `|` to choose randomly from a set works can only be used inside subdivisions (just like in Tidal)
* `,` to stack patterns somewhat works

What isn't implemented:

The shorthand for subdivisions like `a b . c d` -> `[a b] [c d]`, would be nice to have but not really a priority imo

Operator expressions
Probably doable if I ever get around implementing them
* `*` to repeat a pattern
* `?` to mute steps randomly
* `:` to select instrument
* `(s,p,r)` for Euclidean sequences, it's basically just a type of subdivision

The ones that are a bit harder to do because of how I implemented everything to be a step, these would need to add steps instead of adding a Subdivision or changing existing events, it's simpler if the right hand-side is constant but I think it should be any other pattern like in tidal. I'll have to think more about how to cover these nicely..
* `/` to slow down a pattern, this is somewhat unpredictable to use in Tidal
* `@` to elongate a pattern aka `a@3 b`  -> `a _ _ b`
* `!` to replicate a pattern aka `a!3 b` -> `a a a b`

What definitely needs work in the current feature set
* `_` and `~` should be incorporated/filtered out from the outputs, currently they just show up as Hold/Rest events
* error handling and reporting should be cleaned up and made safer, I suppose no `unreachable!` should remain even if the parser grammar seemingly makes something impossible.
* stacks currently just push stuff into the event list, resulting in an unsorted list, it would be probably better to output to a separate vec with each stack and zip them together at the end.
* there should be a converter to eventually get the right type of events instead of the current internal CycleEvent
