### PR TITLE
Cycle Event Time Fractions

### DIFF
--- a/src/event/empty.rs
+++ b/src/event/empty.rs
@@ -1,9 +1,6 @@
 use std::borrow::Cow;
 
-use crate::{
-    event::{Event, EventIter},
-    BeatTimeBase, PulseIterItem,
-};
+use crate::{event::EventIter, BeatTimeBase, EventIterItem, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -25,7 +22,7 @@ impl EventIter for EmptyEventIter {
         _pulse: PulseIterItem,
         _pulse_pattern_length: usize,
         _emit_event: bool,
-    ) -> Option<Vec<Event>> {
+    ) -> Option<Vec<EventIterItem>> {
         None
     }
 

--- a/src/event/fixed.rs
+++ b/src/event/fixed.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-    event::{Event, EventIter, NoteEvent, ParameterChangeEvent},
+    event::{Event, EventIter, EventIterItem, NoteEvent, ParameterChangeEvent},
     BeatTimeBase, Note, PulseIterItem,
 };
 
@@ -48,7 +48,7 @@ impl EventIter for FixedEventIter {
         _pulse: PulseIterItem,
         _pulse_pattern_length: usize,
         emit_event: bool,
-    ) -> Option<Vec<Event>> {
+    ) -> Option<Vec<EventIterItem>> {
         if !emit_event || self.events.is_empty() {
             return None;
         }
@@ -57,7 +57,7 @@ impl EventIter for FixedEventIter {
         if self.event_index >= self.events.len() {
             self.event_index = 0;
         }
-        Some(vec![event])
+        Some(vec![EventIterItem::new(event)])
     }
 
     fn duplicate(&self) -> Box<dyn EventIter> {

--- a/src/event/mutated.rs
+++ b/src/event/mutated.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt::Debug};
 
 use crate::{
-    event::{fixed::FixedEventIter, Event, EventIter},
+    event::{fixed::FixedEventIter, Event, EventIter, EventIterItem},
     BeatTimeBase, PulseIterItem,
 };
 
@@ -77,7 +77,7 @@ impl EventIter for MutatedEventIter {
         _pulse: PulseIterItem,
         _pulse_pattern_length: usize,
         emit_event: bool,
-    ) -> Option<Vec<Event>> {
+    ) -> Option<Vec<EventIterItem>> {
         if emit_event {
             let event = self.events[self.event_index].clone();
             self.events[self.event_index] = Self::mutate(event.clone(), &mut self.map);
@@ -85,7 +85,7 @@ impl EventIter for MutatedEventIter {
             if self.event_index >= self.events.len() {
                 self.event_index = 0;
             }
-            Some(vec![event])
+            Some(vec![EventIterItem::new(event)])
         } else {
             None
         }

--- a/src/event/scripted.rs
+++ b/src/event/scripted.rs
@@ -4,7 +4,7 @@ use mlua::prelude::*;
 
 use crate::{
     bindings::{note_events_from_value, LuaCallback, LuaTimeoutHook},
-    BeatTimeBase, Event, EventIter, PulseIterItem,
+    BeatTimeBase, Event, EventIter, EventIterItem, PulseIterItem,
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ impl ScriptedEventIter {
         &mut self,
         pulse: PulseIterItem,
         pulse_pattern_length: usize,
-    ) -> LuaResult<Option<Vec<Event>>> {
+    ) -> LuaResult<Option<Vec<EventIterItem>>> {
         // reset timeout
         self.timeout_hook.reset();
         // update function context
@@ -70,7 +70,7 @@ impl ScriptedEventIter {
         // invoke callback and evaluate the result
         if let Some(value) = self.callback.call()? {
             let events = note_events_from_value(&value, None)?;
-            Ok(Some(vec![Event::NoteEvents(events)]))
+            Ok(Some(vec![EventIterItem::new(Event::NoteEvents(events))]))
         } else {
             Ok(None)
         }
@@ -111,7 +111,7 @@ impl EventIter for ScriptedEventIter {
         pulse: PulseIterItem,
         pulse_pattern_length: usize,
         emit_event: bool,
-    ) -> Option<Vec<Event>> {
+    ) -> Option<Vec<EventIterItem>> {
         // generate a new event and move or only update pulse counters
         if emit_event {
             let event = match self.next_event(pulse, pulse_pattern_length) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub mod scale;
 pub use scale::Scale;
 
 pub mod event;
-pub use event::{Event, EventIter};
+pub use event::{Event, EventIter, EventIterItem};
 
 pub mod tidal;
 // pub use tidal::{Cycle};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -28,6 +28,7 @@ pub use super::{
     Chord,
     Event,
     EventIter,
+    EventIterItem,
     Gate,
     Note,
     Pattern,


### PR DESCRIPTION
Fixe the temporary note delay hack of https://github.com/emuell/afseq/pull/4 by specifying event start and offset times in a new `EventIterItem` struct.  