### PR TITLE
Feature/cycle mapping

### DIFF
--- a/examples/assets/kick.lua
+++ b/examples/assets/kick.lua
@@ -1,11 +1,12 @@
 return rhythm {
-  unit = "1/16",
-  pattern = function()
-    local pulses = table.create({ 0, 6, 10 })
-    ---@param context PatternContext
-    return function(context)
-      return pulses:find((context.pulse_step - 1) % 16) ~= nil
+  unit = "1/4",
+  resolution = 16,
+  emit = cycle("bd [~ bd] ~ ~ bd [~ bd] _ ~ bd [~ bd] ~ ~ bd [~ bd] [_ bd2] [~ bd _ ~]"):map(
+    function(context, value)
+      -- print(context.channel, context.step, context.step_length, "->", value)
+      if value == "bd" or value == "bd2" then
+        return { key = 48, volume = value == "bd" and 0.9 or 0.5 }
+      end
     end
-  end,
-  emit = { 60, 60, note { 60, { key = 96, volume = 0.135 } } },
+  )
 }

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -71,31 +71,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // generate a few phrases
+    let cycle =
+        new_cycle_event("bd [~ bd] ~ ~ bd [~ bd] _ ~ bd [~ bd] ~ ~ bd [~ bd] [_ bd2] [~ bd _ ~]")?
+            .with_mappings(&[("bd", new_note("c4")), ("bd2", new_note(("c4", None, 0.5)))]);
+
     let kick_pattern = beat_time
-        .every_nth_beat(1.0)
+        .every_nth_beat(16.0)
         .with_instrument(KICK)
-        .with_pattern(
-            vec![
-                Pulse::from(1.0),
-                Pulse::from(vec![0.0, 1.0]),
-                Pulse::from(0.0),
-                Pulse::from(0.0),
-                Pulse::from(1.0),
-                Pulse::from(vec![0.0, 1.0]),
-                Pulse::from(0.0),
-                Pulse::from(0.0),
-                Pulse::from(1.0),
-                Pulse::from(vec![0.0, 1.0]),
-                Pulse::from(0.0),
-                Pulse::from(0.0),
-                Pulse::from(1.0),
-                Pulse::from(vec![0.0, 1.0]),
-                Pulse::from(vec![0.0, 1.0]),
-                Pulse::from(vec![0.0, 1.0, 0.0, 0.0]),
-            ]
-            .to_pattern(),
-        )
-        .trigger(new_note_event("C_5"));
+        .trigger(cycle);
 
     let snare_pattern = beat_time
         .every_nth_beat(2.0)

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -37,13 +37,16 @@ mod timeout;
 mod unwrap;
 
 // public re-exports
-pub use callback::{clear_lua_callback_errors, has_lua_callback_errors, lua_callback_errors};
+pub use callback::{
+    add_lua_callback_error, clear_lua_callback_errors, has_lua_callback_errors, lua_callback_errors,
+};
 
 // internal re-exports
 pub(crate) use callback::LuaCallback;
 pub(crate) use timeout::LuaTimeoutHook;
 pub(crate) use unwrap::{
-    gate_trigger_from_value, note_events_from_value, pattern_pulse_from_value,
+    gate_trigger_from_value, note_event_from_value, note_events_from_value,
+    pattern_pulse_from_value,
 };
 
 // ---------------------------------------------------------------------------------------------

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -191,12 +191,10 @@ mod test {
                     assert(context.beats_per_min, 120)
                     assert(context.beats_per_bar, 4)
                     assert(context.samples_per_sec, 44100)
-                    if value ~= nil then -- TODO!
-                      if value == "wurst" then 
-                        return "c#4"
-                      else
-                        return value..4 
-                      end
+                    if value == "wurst" then
+                      return "c#4"
+                    else
+                      return value..4
                     end
                 end)"#,
         )?;

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -1,6 +1,8 @@
 use mlua::prelude::*;
 
-use crate::tidal::Cycle;
+use crate::{event::NoteEvent, tidal::Cycle};
+
+use super::unwrap::{bad_argument_error, note_event_from_value};
 
 // ---------------------------------------------------------------------------------------------
 
@@ -8,23 +10,40 @@ use crate::tidal::Cycle;
 #[derive(Clone, Debug)]
 pub struct CycleUserData {
     pub cycle: Cycle,
+    pub mappings: Vec<(String, Option<NoteEvent>)>,
 }
 
 impl CycleUserData {
     pub fn from(arg: LuaString, seed: Option<[u8; 32]>) -> LuaResult<Self> {
         // a single value, probably a sequence
         let cycle = Cycle::from(&arg.to_string_lossy(), seed).map_err(LuaError::runtime)?;
-        Ok(CycleUserData { cycle })
+        let mappings = Vec::new();
+        Ok(CycleUserData { cycle, mappings })
     }
 }
 
 impl LuaUserData for CycleUserData {
-    fn add_fields<'lua, F: LuaUserDataFields<'lua, Self>>(_fields: &mut F) {
-        // TODO
-    }
-
-    fn add_methods<'lua, M: LuaUserDataMethods<'lua, Self>>(_methods: &mut M) {
-        // TODO
+    fn add_methods<'lua, M: LuaUserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_method_mut("map", |_lua, this, value: LuaValue| match value {
+            LuaValue::Table(table) => {
+                let cycle = this.cycle.clone();
+                let mut mappings = Vec::new();
+                for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
+                    mappings.push((k.to_string()?, note_event_from_value(&v, None)?));
+                }
+                Ok(CycleUserData { cycle, mappings })
+            }
+            _ => Err(bad_argument_error(
+                None,
+                "map",
+                1,
+                format!(
+                    "map argument must be a table but is a '{}'",
+                    value.type_name()
+                )
+                .as_str(),
+            )),
+        });
     }
 }
 
@@ -32,8 +51,15 @@ impl LuaUserData for CycleUserData {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::*;
-    use crate::bindings::*;
+
+    use crate::{
+        bindings::*,
+        event::{cycle::CycleEventIter, new_note},
+        Event, EventIter, Note, PulseIterItem,
+    };
 
     fn new_test_engine() -> LuaResult<(Lua, LuaTimeoutHook)> {
         let (mut lua, mut timeout_hook) = new_engine()?;
@@ -68,7 +94,62 @@ mod test {
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("")"#).is_err());
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[<")"#).is_err());
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[c4 e6]")"#).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn mappings() -> LuaResult<()> {
+        let (lua, _) = new_test_engine()?;
+
+        let mapped_cycle = evaluate_cycle_userdata(
+            &lua,
+            r#"cycle("a b c"):map({a = "c0", b = 48, c = { key = "c6" }})"#,
+        )?;
+        assert_eq!(
+            mapped_cycle
+                .mappings
+                .clone()
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            HashMap::from([
+                ("a".to_string(), new_note(Note::C0)),
+                ("b".to_string(), new_note(Note::C4)),
+                ("c".to_string(), new_note(Note::C6)),
+            ])
+        );
         
+        // check if mappings are applied correctly
+        let mut event_iter =
+            CycleEventIter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+        assert_eq!(
+            event_iter
+                .run(PulseIterItem::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![
+                Event::NoteEvents(vec![new_note(Note::C0)]),
+                Event::NoteEvents(vec![new_note(Note::C4)]),
+                Event::NoteEvents(vec![new_note(Note::C6)])
+            ])
+        );
+
+        // check instrument overrides
+        let mapped_cycle = evaluate_cycle_userdata(
+            &lua,
+            r#"cycle("a:1 a:2 a"):map({ a = { key = 48, instrument = 66 } })"#,
+        )?;
+        let mut event_iter =
+            CycleEventIter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+        assert_eq!(
+            event_iter
+                .run(PulseIterItem::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![
+                Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(1)))]),
+                Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(2)))]),
+                Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(66)))])
+            ])
+        );
         Ok(())
     }
 }

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -11,6 +11,7 @@ use super::unwrap::{bad_argument_error, note_event_from_value};
 pub struct CycleUserData {
     pub cycle: Cycle,
     pub mappings: Vec<(String, Option<NoteEvent>)>,
+    pub mapping_function: Option<LuaOwnedFunction>,
 }
 
 impl CycleUserData {
@@ -18,20 +19,40 @@ impl CycleUserData {
         // a single value, probably a sequence
         let cycle = Cycle::from(&arg.to_string_lossy(), seed).map_err(LuaError::runtime)?;
         let mappings = Vec::new();
-        Ok(CycleUserData { cycle, mappings })
+        let mapping_function = None;
+        Ok(CycleUserData {
+            cycle,
+            mappings,
+            mapping_function,
+        })
     }
 }
 
 impl LuaUserData for CycleUserData {
     fn add_methods<'lua, M: LuaUserDataMethods<'lua, Self>>(methods: &mut M) {
         methods.add_method_mut("map", |_lua, this, value: LuaValue| match value {
+            LuaValue::Function(func) => {
+                let cycle = this.cycle.clone();
+                let mappings = Vec::new();
+                let mapping_function = Some(func.into_owned());
+                Ok(CycleUserData {
+                    cycle,
+                    mappings,
+                    mapping_function,
+                })
+            }
             LuaValue::Table(table) => {
                 let cycle = this.cycle.clone();
                 let mut mappings = Vec::new();
                 for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
                     mappings.push((k.to_string()?, note_event_from_value(&v, None)?));
                 }
-                Ok(CycleUserData { cycle, mappings })
+                let mapping_function = None;
+                Ok(CycleUserData {
+                    cycle,
+                    mappings,
+                    mapping_function,
+                })
             }
             _ => Err(bad_argument_error(
                 None,
@@ -57,21 +78,21 @@ mod test {
 
     use crate::{
         bindings::*,
-        event::{cycle::CycleEventIter, new_note},
+        event::{cycle::CycleEventIter, new_note, scripted_cycle::ScriptedCycleEventIter},
         Event, EventIter, Note, PulseIterItem,
     };
 
     fn new_test_engine() -> LuaResult<(Lua, LuaTimeoutHook)> {
+        new_test_engine_with_timebase(&BeatTimeBase {
+            beats_per_min: 120.0,
+            beats_per_bar: 4,
+            samples_per_sec: 44100,
+        })
+    }
+
+    fn new_test_engine_with_timebase(time_base: &BeatTimeBase) -> LuaResult<(Lua, LuaTimeoutHook)> {
         let (mut lua, mut timeout_hook) = new_engine()?;
-        register_bindings(
-            &mut lua,
-            &timeout_hook,
-            &BeatTimeBase {
-                beats_per_min: 120.0,
-                beats_per_bar: 4,
-                samples_per_sec: 44100,
-            },
-        )?;
+        register_bindings(&mut lua, &timeout_hook, time_base)?;
         timeout_hook.reset();
         Ok((lua, timeout_hook))
     }
@@ -118,7 +139,7 @@ mod test {
                 ("c".to_string(), new_note(Note::C6)),
             ])
         );
-        
+
         // check if mappings are applied correctly
         let mut event_iter =
             CycleEventIter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
@@ -148,6 +169,54 @@ mod test {
                 Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(1)))]),
                 Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(2)))]),
                 Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(66)))])
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mapping_functions() -> LuaResult<()> {
+        let time_base = BeatTimeBase {
+            beats_per_min: 120.0,
+            beats_per_bar: 4,
+            samples_per_sec: 44100,
+        };
+
+        let (lua, timeout_hook) = new_test_engine_with_timebase(&time_base)?;
+
+        let mapped_cycle = evaluate_cycle_userdata(
+            &lua,
+            r#"
+                cycle("wurst a b c"):map(function(context, value) 
+                    assert(context.beats_per_min, 120)
+                    assert(context.beats_per_bar, 4)
+                    assert(context.samples_per_sec, 44100)
+                    if value ~= nil then -- TODO!
+                      if value == "wurst" then 
+                        return "c#4"
+                      else
+                        return value..4 
+                      end
+                    end
+                end)"#,
+        )?;
+        let mapping_callback =
+            LuaCallback::with_owned(&lua, mapped_cycle.mapping_function.unwrap().clone())?;
+        let mut event_iter = ScriptedCycleEventIter::with_mapping_callback(
+            mapped_cycle.cycle,
+            &timeout_hook,
+            mapping_callback,
+            &time_base,
+        )?;
+        assert_eq!(
+            event_iter
+                .run(PulseIterItem::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![
+                Event::NoteEvents(vec![new_note(Note::Cs4)]),
+                Event::NoteEvents(vec![new_note(Note::A4)]),
+                Event::NoteEvents(vec![new_note(Note::B4)]),
+                Event::NoteEvents(vec![new_note(Note::C4)])
             ])
         );
         Ok(())

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -849,8 +849,9 @@ pub(crate) fn event_iter_from_value(
                 let sequence = userdata.borrow::<SequenceUserData>()?;
                 Ok(Box::new(sequence.notes.clone().to_event_sequence()))
             } else if userdata.is::<CycleUserData>() {
-                let cycle_userdata = userdata.borrow::<CycleUserData>()?;
-                Ok(Box::new(CycleEventIter::new(cycle_userdata.cycle.clone())))
+                let userdata = userdata.borrow::<CycleUserData>()?;
+                let event_iter = CycleEventIter::new(userdata.cycle.clone());
+                Ok(Box::new(event_iter.with_mappings(&userdata.mappings)))
             } else {
                 Err(LuaError::FromLuaConversionError {
                     from: "userdata",

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,6 +21,8 @@ pub mod fixed;
 pub mod mutated;
 #[cfg(feature = "scripting")]
 pub mod scripted;
+#[cfg(feature = "scripting")]
+pub mod scripted_cycle;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -97,10 +97,12 @@ impl CycleNoteEvents {
 
 // -------------------------------------------------------------------------------------------------
 
-/// Emits a vector of [`Event`]S from a Tidal [`Cycle`].
+/// Emits a vector of [`EventIterItem`] from a Tidal [`Cycle`].
 ///
 /// Channels from cycle are merged down into note events on different voices.
-/// Float and String targets are currently unsupported and will result into None events.
+/// Values in cycles can be mapped to notes with an optional mapping table.
+///
+/// See also [`ScriptedCycleEventIter`](`super::scripted_cycle::ScriptedCycleEventIter`)
 #[derive(Clone, Debug)]
 pub struct CycleEventIter {
     cycle: Cycle,

--- a/src/event/empty.rs
+++ b/src/event/empty.rs
@@ -4,7 +4,7 @@ use crate::{event::EventIter, BeatTimeBase, EventIterItem, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
-/// Emits an empty, None [`Event`].
+/// Continuously emits empty [`EventIterItem`]S.
 #[derive(Clone, Debug)]
 pub struct EmptyEventIter {}
 

--- a/src/event/fixed.rs
+++ b/src/event/fixed.rs
@@ -7,7 +7,7 @@ use crate::{
 
 // -------------------------------------------------------------------------------------------------
 
-/// Endlessly emits a single, fixed [`Event`].
+/// Continuously emits a single, fixed [`EventIterItem`].
 #[derive(Clone, Debug)]
 pub struct FixedEventIter {
     events: Vec<Event>,

--- a/src/event/mutated.rs
+++ b/src/event/mutated.rs
@@ -12,7 +12,7 @@ type EventMapFn = dyn FnMut(Event) -> Event + 'static;
 
 // -------------------------------------------------------------------------------------------------
 
-/// Endlessly emits [`Event`] which's value can be mutated in each iter step
+/// Continuously emits [`EventIterItem`] which's value can be mutated in each iter step
 /// with a custom closure.
 ///
 /// NB: This event iter can not be cloned. `clone_dyn` thus will cause a panic!

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -1,0 +1,215 @@
+use std::{borrow::Cow, collections::HashMap};
+
+use fraction::ToPrimitive;
+use mlua::prelude::*;
+
+use crate::{
+    bindings::{add_lua_callback_error, note_event_from_value, LuaCallback, LuaTimeoutHook},
+    event::{cycle::CycleNoteEvents, EventIter, EventIterItem, NoteEvent},
+    BeatTimeBase, PulseIterItem,
+};
+
+use crate::tidal::{Cycle, Event as CycleEvent, Value as CycleValue};
+
+// -------------------------------------------------------------------------------------------------
+
+/// Emits a vector of [`Event`]S from a Tidal [`Cycle`] with optional mapping callbacks from scripts.
+///
+/// See also [`CycleEventIter`](`super::cycle::CycleEventIter`)
+#[derive(Clone, Debug)]
+pub struct ScriptedCycleEventIter {
+    cycle: Cycle,
+    mappings: HashMap<String, Option<NoteEvent>>,
+    mapping_callback: Option<LuaCallback>,
+    timeout_hook: Option<LuaTimeoutHook>,
+    channel_steps: Vec<usize>,
+}
+
+impl ScriptedCycleEventIter {
+    /// Return a new cycle with the given value mappings applied.
+    pub fn with_mappings(cycle: Cycle, mappings: Vec<(String, Option<NoteEvent>)>) -> Self {
+        let mappings = mappings.into_iter().collect();
+        let mapping_callback = None;
+        let timeout_hook = None;
+        let channel_steps = vec![];
+        Self {
+            cycle,
+            mappings,
+            mapping_callback,
+            timeout_hook,
+            channel_steps,
+        }
+    }
+
+    /// Return a new cycle with the given mapping callback applied.
+    pub(crate) fn with_mapping_callback(
+        cycle: Cycle,
+        timeout_hook: &LuaTimeoutHook,
+        mapping_callback: LuaCallback,
+        time_base: &BeatTimeBase,
+    ) -> LuaResult<Self> {
+        // create a new timeout_hook instance and reset it before calling the function
+        let mut timeout_hook = timeout_hook.clone();
+        timeout_hook.reset();
+        let mappings = HashMap::new();
+        // initialize emitter context for the function
+        let mut mapping_callback = mapping_callback;
+        let channel = 0;
+        let step = 0;
+        let step_length = 0.0;
+        mapping_callback.set_cycle_context(time_base, channel, step, step_length)?;
+        let channel_steps = vec![];
+        Ok(Self {
+            cycle,
+            mappings,
+            mapping_callback: Some(mapping_callback),
+            timeout_hook: Some(timeout_hook),
+            channel_steps,
+        })
+    }
+
+    /// Generate a note event from a single cycle event, applying mappings if necessary
+    fn note_event(
+        &mut self,
+        channel_index: usize,
+        _event_index: usize,
+        event_length: f64,
+        event: CycleEvent,
+    ) -> LuaResult<Option<NoteEvent>> {
+        let mut note_event = {
+            if let Some(mapping_callback) = self.mapping_callback.as_mut() {
+                // increase step counter
+                if self.channel_steps.len() <= channel_index {
+                    self.channel_steps.resize(channel_index + 1, 0);
+                }
+                let channel_step = self.channel_steps[channel_index];
+                self.channel_steps[channel_index] += 1;
+                // update step in context
+                mapping_callback.set_context_cycle_step(
+                    channel_index,
+                    channel_step,
+                    event_length,
+                )?;
+                // call mapping function
+                let result = mapping_callback.call_with_arg(event.string())?;
+                note_event_from_value(&result, None)?
+            } else if let Some(mapped_note_event) = self.mappings.get(event.string()) {
+                // apply custom note mapping
+                mapped_note_event.clone()
+            } else {
+                // else try to convert value to a note
+                event.value().into()
+            }
+        };
+        // verify that all identifiers are mapped
+        if note_event.is_none()
+            && self.mapping_callback.is_none()
+            && !matches!(event.value(), CycleValue::Rest | CycleValue::Hold)
+        {
+            return Err(LuaError::runtime(format!(
+                "invalid/unknown identifier in cycle: '{}'. please check for typos or add a custom mapping for it.",
+                event.string()
+            )));
+        }
+        // inject target instrument, if present
+        if let Some(instrument) = event.target().into() {
+            if let Some(note_event) = &mut note_event {
+                note_event.instrument = Some(instrument);
+            }
+        }
+        Ok(note_event)
+    }
+
+    /// Generate next batch of events from the next cycle run.
+    /// Converts cycle events to note events and flattens channels into note columns.
+    fn generate_events(&mut self) -> Vec<EventIterItem> {
+        // reset timeout hook for mapping functions
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            timeout_hook.reset();
+        }
+        // convert possibly mapped cycle channel items to a list of note events
+        let mut timed_note_events = CycleNoteEvents::new();
+        for (channel_index, channel_events) in self.cycle.generate().into_iter().enumerate() {
+            for (event_index, event) in channel_events.into_iter().enumerate() {
+                let start = event.span().start();
+                let length = event.span().length();
+                let event_length = length.to_f64().unwrap_or_default();
+                match self.note_event(channel_index, event_index, event_length, event) {
+                    Err(err) => {
+                        if let Some(callback) = &self.mapping_callback {
+                            callback.handle_error(&err)
+                        } else {
+                            add_lua_callback_error("map", &err)
+                        }
+                    }
+                    Ok(note_event) => {
+                        if let Some(note_event) = note_event {
+                            timed_note_events.add(channel_index, start, length, note_event);
+                        }
+                    }
+                }
+            }
+        }
+        // convert timed note events into EventIterItems
+        timed_note_events.into_event_iter_items()
+    }
+}
+
+impl EventIter for ScriptedCycleEventIter {
+    fn set_time_base(&mut self, time_base: &BeatTimeBase) {
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            timeout_hook.reset();
+        }
+        if let Some(callback) = &mut self.mapping_callback {
+            if let Err(err) = callback.set_context_time_base(time_base) {
+                callback.handle_error(&err);
+            }
+        }
+    }
+
+    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            timeout_hook.reset();
+        }
+        if let Some(callback) = &mut self.mapping_callback {
+            if let Err(err) = callback.set_context_external_data(data) {
+                callback.handle_error(&err);
+            }
+        }
+    }
+
+    fn run(&mut self, _pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>> {
+        if emit_event {
+            Some(self.generate_events())
+        } else {
+            None
+        }
+    }
+
+    fn duplicate(&self) -> Box<dyn EventIter> {
+        Box::new(self.clone())
+    }
+
+    fn reset(&mut self) {
+        // reset cycle
+        self.cycle.reset();
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            // reset timeout
+            timeout_hook.reset();
+        }
+        if let Some(callback) = &mut self.mapping_callback {
+            // reset step counter
+            let channel = 0;
+            let step = 0;
+            let step_length = 0.0;
+            self.channel_steps.clear();
+            if let Err(err) = callback.set_context_cycle_step(channel, step, step_length) {
+                callback.handle_error(&err);
+            }
+            // restore function
+            if let Err(err) = callback.reset() {
+                callback.handle_error(&err);
+            }
+        }
+    }
+}

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -13,7 +13,11 @@ use crate::tidal::{Cycle, Event as CycleEvent, Value as CycleValue};
 
 // -------------------------------------------------------------------------------------------------
 
-/// Emits a vector of [`Event`]S from a Tidal [`Cycle`] with optional mapping callbacks from scripts.
+/// Emits a vector of [`EventIterItem`] from a Tidal [`Cycle`].
+///
+/// Channels from cycle are merged down into note events on different voices.
+/// Values in cycles can be mapped to notes with an optional mapping table or
+/// callbacks from from scripts.
 ///
 /// See also [`CycleEventIter`](`super::cycle::CycleEventIter`)
 #[derive(Clone, Debug)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -53,9 +53,9 @@ pub use super::{
         clear_lua_callback_errors, has_lua_callback_errors, lua_callback_errors,
         new_rhythm_from_file, new_rhythm_from_string,
     },
-    event::scripted::ScriptedEventIter,
-    pattern::scripted::ScriptedPattern,
+    event::{scripted::ScriptedEventIter, scripted_cycle::ScriptedCycleEventIter},
     gate::scripted::ScriptedGate,
+    pattern::scripted::ScriptedPattern,
 };
 
 #[cfg(feature = "player")]

--- a/types/nerdo/library/cycle.lua
+++ b/types/nerdo/library/cycle.lua
@@ -11,6 +11,29 @@ local Cycle = {}
 
 ----------------------------------------------------------------------------------------------------
 
+---Map names in in the cycle to custom note events.
+---
+---By default, strings in cycles are interpreted as notes, and integer values as MIDI note
+---values. Custom identifiers such as "bd" are undefined and will result into a rest, when
+---they are not mapped explicitely.
+---
+---Chords such as "c4'major" are not (yet) supported as values.
+---@param map { [string]: NoteValue}
+---@return Cycle
+---### examples:
+---```lua
+---cycle("bd [bd sn]"):map({
+---  bd = "c4",
+---  sn = "e4 #1 v0.2"
+---})
+---cycle("bd:1 <bd:5, bd:7>"):map({
+---  bd = { key = "c4", volume = 0.5 }, -- instrument #1,5,7 will be set as specified
+---})
+---```
+function Cycle:map(map) end
+
+----------------------------------------------------------------------------------------------------
+
 --- Create a note sequence from a Tidal Cycles mini-notation string.
 ---
 --- `cycle` accepts a mini-notation as used by Tidal Cycles, with the following differences:
@@ -23,7 +46,7 @@ local Cycle = {}
 ---@return Cycle
 ---### examples:
 --- ```lua
------A chord sequence 
+-----A chord sequence
 ---cycle("[c4, e4, g4] [e4, g4, b4] [g4, b4, d5] [b4, d5, f#5]")
 -----Arpegio pattern with variations
 ---cycle("<c4 e4 g4> <e4 g4> <g4 b4 d5> <b4 f5>")
@@ -31,5 +54,7 @@ local Cycle = {}
 ---cycle("c4(3,8) e4(5,8) g4(7,8)")
 -----Polyrhythm
 ---cycle("{c4 e4 g4 b4}%2, {f4 d4 a4}%4")
+-----Custom name mappings
+---cycle("bd(3,8)"):map({ bd = "c4 #1" })
 --- ```
 function cycle(input) end

--- a/types/nerdo/library/cycle.lua
+++ b/types/nerdo/library/cycle.lua
@@ -6,18 +6,16 @@
 
 ----------------------------------------------------------------------------------------------------
 
----Context passed to 'emit' functions.
+---Context passed to 'cycle:map` functions.
 ---@class CycleMapContext : TimeContext
 ---
 ---channel/voice index within the cycle. each channel in the cycle gets emitted and thus mapped
 ---separately, starting with the first channel index 1.
 ---@field channel integer
----Continues step counter for each channel, incrementing with each new value in the cycle.
----Unlike `pulse_step` this does not include holds so it basically counts how often the map
----function already got called.
----Starts from 1 when the rhythm starts running or after it got reset.
+---Continues step counter for each channel, incrementing with each new mapped value in the cycle.
+---Starts from 1 when the cycle starts running or after it got reset.
 ---@field step integer
----step length fraction within the cycle
+---step length fraction within the cycle, where 1 is the total duration of a single cycle run.
 ---@field step_length number
 
 ----------------------------------------------------------------------------------------------------

--- a/types/nerdo/library/rhythm.lua
+++ b/types/nerdo/library/rhythm.lua
@@ -19,13 +19,19 @@ error("Do not try to execute this file. It's just a type definition file.")
 ----------------------------------------------------------------------------------------------------
 
 ---Context passed to `pattern` functions.
----@class PatternContext : TriggerContext
+---@class TimeContext : TriggerContext
+---
 -----Project's tempo in beats per minutes.
 ---@field beats_per_min number
 -----Project's beats per bar setting.
 ---@field beats_per_bar integer
 -----Project's sample rate in samples per second.
 ---@field samples_per_sec integer
+
+----------------------------------------------------------------------------------------------------
+
+---Context passed to `pattern` functions.
+---@class PatternContext : TimeContext
 ---
 ---Continues pulse counter, incrementing with each new **skipped or emitted pulse**.
 ---Unlike `step` in emitter this includes all pulses, so it also counts pulses which do


### PR DESCRIPTION
See #13 

This allows mapping identifiers and other existing note values in cycles to custom note values via a static map (a table, in Lua):

```lua
cycle("bd(3,8)"):map({ bd = "c4 #1" })  
```

... and via a function callback:

```lua
cycle("4 5 4 <4 [5|7]>"):map(function(context)
  local notes = scale("c", "minor").notes
  return function(context, value)
    -- dummy example: emit a cmin note arp with 'value' as octave
    local note = notes[math.imod(context.step, #notes)]
    local octave = tonumber(value)
    return { key = note + octave * 12 }
  end
end)
```

Context in map functions contains global info such as transport timing and also maintains step counters which are running individually for each channel in the cycle. 

```lua
---Context passed to 'cycle:map` functions.
---@class CycleMapContext : TimeContext
---
---channel/voice index within the cycle. each channel in the cycle gets emitted and thus mapped
---separately, starting with the first channel index 1.
---@field channel integer
---Continues step counter for each channel, incrementing with each new value in the cycle.
---Starts from 1 when the rhythm starts running or after it got reset.
---@field step integer
---step length fraction within the cycle, where 1 is the total duration of a single cycle run.
---@field step_length number
```

---

Only single notes can be used as mapped value. Chords and thus also stuff like `note('c4')` values are not yet supported. This will be done in a separate PR.

As soon as we allow chords in mappings, we can also add some helper mappings and function to ease mapping scales and stuff.

@unlessgames We likely do conflict here: I've added a new "string"  property to Event, which is used as key for the mapping.
Decide you if we merge this PR or yours first. 