### PR TITLE
Feature/cycle event limit

### DIFF
--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -16,8 +16,10 @@ pub struct CycleUserData {
 
 impl CycleUserData {
     pub fn from(arg: LuaString, seed: Option<[u8; 32]>) -> LuaResult<Self> {
-        // a single value, probably a sequence
-        let cycle = Cycle::from(&arg.to_string_lossy(), seed).map_err(LuaError::runtime)?;
+        let mut cycle = Cycle::from(&arg.to_string_lossy()).map_err(LuaError::runtime)?;
+        if let Some(seed) = seed {
+            cycle = cycle.with_seed(seed);
+        }
         let mappings = Vec::new();
         let mapping_function = None;
         Ok(CycleUserData {

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -165,7 +165,8 @@ impl CycleEventIter {
     fn generate_events(&mut self) -> Vec<EventIterItem> {
         let mut timed_note_events = CycleNoteEvents::new();
         // convert possibly mapped cycle channel items to a list of note events
-        for (channel_index, channel_events) in self.cycle.generate().into_iter().enumerate() {
+        let events = self.cycle.generate().unwrap_or_default();
+        for (channel_index, channel_events) in events.into_iter().enumerate() {
             for event in channel_events.into_iter() {
                 let start = event.span().start();
                 let length = event.span().length();

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -120,15 +120,15 @@ impl CycleEventIter {
     ///
     /// Returns error when the cycle string failed to parse.
     pub fn from_mini(input: &str) -> Result<Self, String> {
-        Ok(Self::new(Cycle::from(input, None)?))
+        Ok(Self::new(Cycle::from(input)?))
     }
 
     /// Try creating a new cycle event iter from the given mini notation string
     /// and the given seed for the cycle's random number generator.
     ///
     /// Returns error when the cycle string failed to parse.
-    pub fn from_mini_with_seed(input: &str, seed: Option<[u8; 32]>) -> Result<Self, String> {
-        Ok(Self::new(Cycle::from(input, seed)?))
+    pub fn from_mini_with_seed(input: &str, seed: [u8; 32]) -> Result<Self, String> {
+        Ok(Self::new(Cycle::from(input)?.with_seed(seed)))
     }
 
     /// Return a new cycle with the given value mappings applied.
@@ -223,7 +223,7 @@ pub fn new_cycle_event(input: &str) -> Result<CycleEventIter, String> {
 
 pub fn new_cycle_event_with_seed(
     input: &str,
-    seed: Option<[u8; 32]>,
+    seed: [u8; 32],
 ) -> Result<CycleEventIter, String> {
     CycleEventIter::from_mini_with_seed(input, seed)
 }

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -163,9 +163,18 @@ impl CycleEventIter {
     /// Generate next batch of events from the next cycle run.
     /// Converts cycle events to note events and flattens channels into note columns.
     fn generate_events(&mut self) -> Vec<EventIterItem> {
+        // run the cycle event generator
+        let events = {
+            match self.cycle.generate() {
+                Ok(events) => events,
+                Err(err) => {
+                    // NB: only expected error here is exceeding the event limit  
+                    panic!("Cycle runtime error: {err}");
+                }
+            }
+        };
         let mut timed_note_events = CycleNoteEvents::new();
         // convert possibly mapped cycle channel items to a list of note events
-        let events = self.cycle.generate().unwrap_or_default();
         for (channel_index, channel_events) in events.into_iter().enumerate() {
             for event in channel_events.into_iter() {
                 let start = event.span().start();

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -133,7 +133,8 @@ impl ScriptedCycleEventIter {
         }
         // convert possibly mapped cycle channel items to a list of note events
         let mut timed_note_events = CycleNoteEvents::new();
-        for (channel_index, channel_events) in self.cycle.generate().into_iter().enumerate() {
+        let events = self.cycle.generate().unwrap_or_default();
+        for (channel_index, channel_events) in events.into_iter().enumerate() {
             for (event_index, event) in channel_events.into_iter().enumerate() {
                 let start = event.span().start();
                 let length = event.span().length();

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -127,13 +127,23 @@ impl ScriptedCycleEventIter {
     /// Generate next batch of events from the next cycle run.
     /// Converts cycle events to note events and flattens channels into note columns.
     fn generate_events(&mut self) -> Vec<EventIterItem> {
+        // run the cycle event generator
+        let events = {
+            match self.cycle.generate() {
+                Ok(events) => events,
+                Err(err) => {
+                    add_lua_callback_error("cycle", &LuaError::RuntimeError(err));
+                    // skip processing events
+                    return vec![];
+                }
+            }
+        };
         // reset timeout hook for mapping functions
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
         // convert possibly mapped cycle channel items to a list of note events
         let mut timed_note_events = CycleNoteEvents::new();
-        let events = self.cycle.generate().unwrap_or_default();
         for (channel_index, channel_events) in events.into_iter().enumerate() {
             for (event_index, event) in channel_events.into_iter().enumerate() {
                 let start = event.span().start();

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1370,25 +1370,27 @@ impl Cycle {
         cycle: u32,
         limit: usize,
     ) -> Result<Events, String> {
-        state.events += 1;
-        if state.events > limit {
-            return Err(format!(
-                "the cycle's event limit of {} was exceeded!",
-                limit
-            ));
-        }
         let events = match step {
             // repeats only make it here if they had no preceding value
             Step::Repeat => Events::empty(),
             // ranges get applied at parse time
             Step::Range(_) => Events::empty(),
-            Step::Single(s) => Events::Single(Event {
-                length: Fraction::one(),
-                target: Target::None,
-                span: Span::default(),
-                string: s.string.clone(),
-                value: s.value.clone(),
-            }),
+            Step::Single(s) => {
+                state.events += 1;
+                if state.events > limit {
+                    return Err(format!(
+                        "the cycle's event limit of {} was exceeded!",
+                        limit
+                    ));
+                }
+                Events::Single(Event {
+                    length: Fraction::one(),
+                    target: Target::None,
+                    span: Span::default(),
+                    string: s.string.clone(),
+                    value: s.value.clone(),
+                })
+            }
             Step::Subdivision(sd) => {
                 if sd.steps.is_empty() {
                     Events::empty()

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -17,11 +17,11 @@ use crate::pattern::euclidean::euclidean;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Cycle {
     root: Step,
+    event_limit: usize,
     input: String,
     seed: Option<[u8; 32]>,
     state: CycleState,
 }
-
 impl Cycle {
     /// create a Cycle from an mini-notation string with an optional seed
     pub fn from(input: &str, seed: Option<[u8; 32]>) -> Result<Self, String> {
@@ -48,6 +48,7 @@ impl Cycle {
                         seed,
                         root,
                         state,
+                        event_limit: 0x1000,
                     };
                     #[cfg(test)]
                     {
@@ -72,14 +73,14 @@ impl Cycle {
     }
 
     /// query for the next iteration of output
-    pub fn generate(&mut self) -> Vec<Vec<Event>> {
+    pub fn generate(&mut self) -> Result<Vec<Vec<Event>>, String> {
         let cycle = self.state.iteration;
         self.state.events = 0;
         self.state.step = 0;
-        let mut events = Self::output(&self.root, &mut self.state, cycle);
+        let mut events = Self::output(&self.root, &mut self.state, cycle, self.event_limit)?;
         self.state.iteration += 1;
         events.transform_spans(&Span::default());
-        events.export()
+        Ok(events.export())
     }
 
     /// reset state to initial state
@@ -1320,27 +1321,30 @@ struct CycleState {
     iteration: u32,
     rng: Xoshiro256PlusPlus,
     step: u32,
-    events: u32,
+    events: usize,
 }
 
 impl Cycle {
-    fn output_span(step: &Step, state: &mut CycleState, span: &Span) -> Events {
+    fn output_span(
+        step: &Step,
+        state: &mut CycleState,
+        span: &Span,
+        limit: usize,
+    ) -> Result<Events, String> {
         let range = span.whole_range();
-        let cycles = range
-            .map(|cycle| {
-                let mut events = Self::output(step, state, cycle);
-                events
-                    .transform_spans(&Span::new(Fraction::from(cycle), Fraction::from(cycle + 1)));
-                events
-            })
-            .collect();
+        let mut cycles = vec![];
+        for cycle in range {
+            let mut events = Self::output(step, state, cycle, limit)?;
+            events.transform_spans(&Span::new(Fraction::from(cycle), Fraction::from(cycle + 1)));
+            cycles.push(events)
+        }
         let mut events = Events::Multi(MultiEvents {
             span: span.clone(),
             length: span.length(),
             events: cycles,
         });
         events.crop(span);
-        events
+        Ok(events)
     }
 
     fn output_multiplied(
@@ -1348,23 +1352,32 @@ impl Cycle {
         state: &mut CycleState,
         cycle: u32,
         mult: Fraction,
-    ) -> Events {
+        limit: usize,
+    ) -> Result<Events, String> {
         let span = Span::new(
             Fraction::from(cycle) * mult,
             Fraction::from(cycle + 1) * mult,
         );
-        let mut events = Self::output_span(step, state, &span);
+        let mut events = Self::output_span(step, state, &span, limit)?;
         events.normalize_spans(&span);
-        events
+        Ok(events)
     }
 
     // recursively output events for the entire cycle based on some state (random seed)
-    fn output(step: &Step, state: &mut CycleState, cycle: u32) -> Events {
+    fn output(
+        step: &Step,
+        state: &mut CycleState,
+        cycle: u32,
+        limit: usize,
+    ) -> Result<Events, String> {
         state.events += 1;
-        if state.events > 1024 {
-            return Events::empty();
+        if state.events > limit {
+            return Err(format!(
+                "the cycle's event limit of {} was exceeded!",
+                limit
+            ));
         }
-        match step {
+        let events = match step {
             // repeats only make it here if they had no preceding value
             Step::Repeat => Events::empty(),
             // ranges get applied at parse time
@@ -1382,7 +1395,7 @@ impl Cycle {
                 } else {
                     let mut events = vec![];
                     for s in &sd.steps {
-                        let e = Self::output(s, state, cycle);
+                        let e = Self::output(s, state, cycle, limit)?;
                         events.push(e)
                     }
 
@@ -1401,7 +1414,7 @@ impl Cycle {
                     let length = a.steps.len() as u32;
                     let current = cycle % length;
                     if let Some(step) = a.steps.get(current as usize) {
-                        Self::output(step, state, cycle / length)
+                        Self::output(step, state, cycle / length, limit)?
                     } else {
                         Events::empty() // unreachable
                     }
@@ -1409,7 +1422,7 @@ impl Cycle {
             }
             Step::Choices(cs) => {
                 let choice = state.rng.gen_range(0..cs.choices.len());
-                Self::output(&cs.choices[choice], state, cycle) // TODO seed the rng properly
+                Self::output(&cs.choices[choice], state, cycle, limit)? // TODO seed the rng properly
             }
             Step::Polymeter(pm) => {
                 let step = pm.steps.as_ref();
@@ -1419,7 +1432,7 @@ impl Cycle {
                     _ => 1,
                 };
                 let mult = Fraction::from(count) / Fraction::from(length);
-                Self::output_multiplied(step, state, cycle, mult)
+                Self::output_multiplied(step, state, cycle, mult, limit)?
             }
             Step::Stack(st) => {
                 if st.stack.is_empty() {
@@ -1427,7 +1440,7 @@ impl Cycle {
                 } else {
                     let mut channels = vec![];
                     for s in &st.stack {
-                        channels.push(Self::output(s, state, cycle))
+                        channels.push(Self::output(s, state, cycle, limit)?)
                     }
                     Events::Poly(PolyEvents {
                         span: Span::default(),
@@ -1439,12 +1452,12 @@ impl Cycle {
             Step::StaticExpression(e) => {
                 match e.op {
                     StaticOp::Target() => {
-                        let mut out = Self::output(e.left.as_ref(), state, cycle);
+                        let mut out = Self::output(e.left.as_ref(), state, cycle, limit)?;
                         out.mutate_events(&mut |event| event.target = e.right.to_target());
                         out
                     }
                     StaticOp::Degrade() => {
-                        let mut out = Self::output(e.left.as_ref(), state, cycle);
+                        let mut out = Self::output(e.left.as_ref(), state, cycle, limit)?;
                         out.mutate_events(&mut |event: &mut Event| {
                             if let Some(chance) = e.right.to_chance() {
                                 // TODO seed the rng properly
@@ -1472,7 +1485,7 @@ impl Cycle {
                             } else {
                                 right
                             });
-                            Self::output_multiplied(e.left.as_ref(), state, cycle, mult)
+                            Self::output_multiplied(e.left.as_ref(), state, cycle, mult, limit)?
                         } else {
                             Events::empty()
                         }
@@ -1499,7 +1512,8 @@ impl Cycle {
                                 };
                                 if let Some(steps) = steps_single.value.to_integer() {
                                     if let Some(pulses) = pulses_single.value.to_integer() {
-                                        let out = Self::output(b.left.as_ref(), state, cycle);
+                                        let out =
+                                            Self::output(b.left.as_ref(), state, cycle, limit)?;
                                         for pulse in euclidean(
                                             steps.max(0) as u32,
                                             pulses.max(0) as u32,
@@ -1526,7 +1540,8 @@ impl Cycle {
                     events,
                 })
             }
-        }
+        };
+        Ok(events)
     }
 
     #[cfg(test)]
@@ -1593,15 +1608,15 @@ mod test {
     fn assert_cycles(input: &str, outputs: Vec<Vec<Vec<Event>>>) -> Result<(), String> {
         let mut cycle = Cycle::from(input, None)?;
         for out in outputs {
-            assert_eq!(cycle.generate(), out);
+            assert_eq!(cycle.generate()?, out);
         }
         Ok(())
     }
 
     fn assert_cycle_equality(a: &str, b: &str) -> Result<(), String> {
         assert_eq!(
-            Cycle::from(a, None)?.generate(),
-            Cycle::from(b, None)?.generate(),
+            Cycle::from(a, None)?.generate()?,
+            Cycle::from(b, None)?.generate()?,
         );
         Ok(())
     }
@@ -1610,7 +1625,7 @@ mod test {
 
     pub fn cycle() -> Result<(), String> {
         assert_eq!(
-            Cycle::from("a b c d", None)?.generate(),
+            Cycle::from("a b c d", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 4u8)).with_note(9, 4),
                 Event::at(F::new(1u8, 4u8), F::new(1u8, 4u8)).with_note(11, 4),
@@ -1619,11 +1634,11 @@ mod test {
             ]]
         );
         assert_eq!(
-            Cycle::from("\ta\r\n\tb\nc\n d\n\n", None)?.generate(),
-            Cycle::from("a b c d", None)?.generate()
+            Cycle::from("\ta\r\n\tb\nc\n d\n\n", None)?.generate()?,
+            Cycle::from("a b c d", None)?.generate()?
         );
         assert_eq!(
-            Cycle::from("a b [ c d ]", None)?.generate(),
+            Cycle::from("a b [ c d ]", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 3u8)).with_note(9, 4),
                 Event::at(F::new(1u8, 3u8), F::new(1u8, 3u8)).with_note(11, 4),
@@ -1632,7 +1647,7 @@ mod test {
             ]]
         );
         assert_eq!(
-            Cycle::from("[a a] [b4 b5 b6] [c0 d1 c2 d3]", None)?.generate(),
+            Cycle::from("[a a] [b4 b5 b6] [c0 d1 c2 d3]", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 6u8)).with_note(9, 4),
                 Event::at(F::new(1u8, 6u8), F::new(1u8, 6u8)).with_note(9, 4),
@@ -1646,7 +1661,7 @@ mod test {
             ]]
         );
         assert_eq!(
-            Cycle::from("[a0 [bb1 [b2 c3]]] c#4 [[[d5 D#6] E7 ] F8]", None)?.generate(),
+            Cycle::from("[a0 [bb1 [b2 c3]]] c#4 [[[d5 D#6] E7 ] F8]", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 6u8)).with_note(9, 0),
                 Event::at(F::new(1u8, 6u8), F::new(1u8, 12u8)).with_note(10, 1),
@@ -1660,7 +1675,7 @@ mod test {
             ]]
         );
         assert_eq!(
-            Cycle::from("[R [e [n o]]] , [[[i s] e ] _]", None)?.generate(),
+            Cycle::from("[R [e [n o]]] , [[[i s] e ] _]", None)?.generate()?,
             vec![
                 vec![
                     Event::at(F::from(0), F::new(1u8, 2u8)).with_name("R"),
@@ -1781,7 +1796,7 @@ mod test {
         )?;
 
         assert_eq!(
-            Cycle::from("[1 middle _] {}%42 [] <>", None)?.generate(),
+            Cycle::from("[1 middle _] {}%42 [] <>", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 12u8)).with_int(1),
                 Event::at(F::new(1u8, 12u8), F::new(1u8, 6u8)).with_name("middle"),
@@ -1810,7 +1825,7 @@ mod test {
         )?;
 
         assert_eq!(
-            Cycle::from("1 second*2 eb3*3 [32 32]*4", None)?.generate(),
+            Cycle::from("1 second*2 eb3*3 [32 32]*4", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 4u8)).with_int(1),
                 Event::at(F::new(2u8, 8u8), F::new(1u8, 8u8)).with_name("second"),
@@ -1886,7 +1901,7 @@ mod test {
         )?;
 
         assert_eq!(
-            Cycle::from("1!2 3 [4!3 5]", None)?.generate(),
+            Cycle::from("1!2 3 [4!3 5]", None)?.generate()?,
             [[
                 Event::at(F::from(0), F::new(1u8, 4u8)).with_int(1),
                 Event::at(F::new(1u8, 4u8), F::new(1u8, 4u8)).with_int(1),
@@ -1949,7 +1964,7 @@ mod test {
         )?;
 
         assert_eq!(
-            Cycle::from("c(3,8,9)", None)?.generate(),
+            Cycle::from("c(3,8,9)", None)?.generate()?,
             [[
                 Event::at(F::new(2u8, 8u8), F::new(1u8, 8u8)).with_note(0, 4),
                 Event::at(F::new(3u8, 8u8), F::new(1u8, 4u8)),
@@ -2022,6 +2037,9 @@ mod test {
 
         // TODO test random outputs // parse_with_debug("[a b c d]?0.5");
 
+        assert!(Cycle::from("[[a b c d]*100]*100", None)?
+            .generate()
+            .is_err());
         assert!(Cycle::from("a b c [d", None).is_err());
         assert!(Cycle::from("a b/ c [d", None).is_err());
         assert!(Cycle::from("a b--- c [d", None).is_err());


### PR DESCRIPTION
Implementing #9

`Cycle::generate` now returns a `Result` that fails if the output exceeds the limit defined for the Cycle (currently `0x1000`).

I changed the files that used `Cycle::generate` to avoid errors (they just output no events in case of a fail), but I suppose the error should be propagated up to the user. I could look into this but maybe it's best if you implement the rest of this however you want.