### PR TITLE
Cycle chords & chord mapping

### DIFF
--- a/examples/play.rs
+++ b/examples/play.rs
@@ -73,7 +73,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // generate a few phrases
     let cycle =
         new_cycle_event("bd [~ bd] ~ ~ bd [~ bd] _ ~ bd [~ bd] ~ ~ bd [~ bd] [_ bd2] [~ bd _ ~]")?
-            .with_mappings(&[("bd", new_note("c4")), ("bd2", new_note(("c4", None, 0.5)))]);
+            .with_mappings(&[
+                ("bd", vec![new_note("c4")]),
+                ("bd2", vec![new_note(("c4", None, 0.5))]),
+            ]);
 
     let kick_pattern = beat_time
         .every_nth_beat(16.0)

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -45,8 +45,7 @@ pub use callback::{
 pub(crate) use callback::LuaCallback;
 pub(crate) use timeout::LuaTimeoutHook;
 pub(crate) use unwrap::{
-    gate_trigger_from_value, note_event_from_value, note_events_from_value,
-    pattern_pulse_from_value,
+    gate_trigger_from_value, note_events_from_value, pattern_pulse_from_value,
 };
 
 // ---------------------------------------------------------------------------------------------

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -2,7 +2,7 @@ use mlua::prelude::*;
 
 use crate::{event::NoteEvent, tidal::Cycle};
 
-use super::unwrap::{bad_argument_error, note_event_from_value};
+use super::unwrap::{bad_argument_error, note_events_from_value};
 
 // ---------------------------------------------------------------------------------------------
 
@@ -10,7 +10,7 @@ use super::unwrap::{bad_argument_error, note_event_from_value};
 #[derive(Clone, Debug)]
 pub struct CycleUserData {
     pub cycle: Cycle,
-    pub mappings: Vec<(String, Option<NoteEvent>)>,
+    pub mappings: Vec<(String, Vec<Option<NoteEvent>>)>,
     pub mapping_function: Option<LuaOwnedFunction>,
 }
 
@@ -47,7 +47,7 @@ impl LuaUserData for CycleUserData {
                 let cycle = this.cycle.clone();
                 let mut mappings = Vec::new();
                 for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
-                    mappings.push((k.to_string()?, note_event_from_value(&v, None)?));
+                    mappings.push((k.to_string()?, note_events_from_value(&v, None)?));
                 }
                 let mapping_function = None;
                 Ok(CycleUserData {
@@ -136,9 +136,9 @@ mod test {
                 .into_iter()
                 .collect::<HashMap<_, _>>(),
             HashMap::from([
-                ("a".to_string(), new_note(Note::C0)),
-                ("b".to_string(), new_note(Note::C4)),
-                ("c".to_string(), new_note(Note::C6)),
+                ("a".to_string(), vec![new_note(Note::C0)]),
+                ("b".to_string(), vec![new_note(Note::C4)]),
+                ("c".to_string(), vec![new_note(Note::C6)]),
             ])
         );
 

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -101,8 +101,8 @@ impl ScriptedCycleEventIter {
                 // apply custom note mapping
                 note_events.clone()
             } else {
-                // convert the cycle value to a single note
-                vec![event.value().into()]
+                // try converting the cycle value to a single note
+                event.value().try_into().map_err(LuaError::RuntimeError)?
             }
         };
         // verify that all identifiers are mapped

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -16,13 +16,17 @@ number  = ${ (normal | float | integer) ~ !(ASCII_ALPHA) }
 octave  = { "10" | ASCII_DIGIT }
 mark    = { "#"|"b" }
 note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
-pitch   = ${ note ~ mark? ~ octave? ~ !(ASCII_ALPHANUMERIC)}
+pitch   = ${ note ~ mark? ~ octave? ~ !name}
+
+/// chord as pitch with mode string, separated via "'"
+mode    = ${ (ASCII_ALPHANUMERIC | "#" | "-" | "+" | "\u{0394}")+ }
+chord   = ${ pitch ~ "'" ~ mode }
 
 /// type for empty steps
-rest = @{ ("~" | "-") ~ !(ASCII_ALPHANUMERIC) }
+rest = @{ ("~" | "-") ~ !name }
 
 /// type for held steps
-hold = @{ "_" ~ !(ASCII_ALPHANUMERIC) }
+hold = @{ "_" ~ !name }
 
 /// arbitrary string identifier type
 name = @{ (ASCII_ALPHANUMERIC | "_")+ }
@@ -30,7 +34,7 @@ name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 repeat = { "!" }
 
 /// possible literals for single steps
-single = { hold | rest | number | pitch | name }
+single = { hold | rest | number | chord | pitch | name }
 
 /// groups
 subdivision     = { "[" ~ (stack | split | choices | section)? ~ "]" }

--- a/types/nerdo/library/cycle.lua
+++ b/types/nerdo/library/cycle.lua
@@ -25,22 +25,21 @@ local Cycle = {}
 
 ----------------------------------------------------------------------------------------------------
 
----@alias MapFunction fun(context: CycleMapContext, value: string):NoteValue
----@alias MapGenerator fun(context: CycleMapContext, value: string):MapFunction
+---@alias CycleMapNoteValue NoteValue|(NoteValue[])|Note
+---@alias CycleMapFunction fun(context: CycleMapContext, value: string):CycleMapNoteValue
+---@alias CycleMapGenerator fun(context: CycleMapContext, value: string):CycleMapFunction
 
 ---Map names in in the cycle to custom note events.
 ---
 ---By default, strings in cycles are interpreted as notes, and integer values as MIDI note
 ---values. Custom identifiers such as "bd" are undefined and will result into a rest, when
 ---they are not mapped explicitely.
----
----Chords such as "c4'major" are not (yet) supported as values.
----@param map { [string]: NoteValue }
+---@param map { [string]: CycleMapNoteValue }
 ---@return Cycle
 ---### examples:
 ---```lua
 -----Using a fixed mapping table
----cycle("bd [bd sn]"):map({
+---cycle("bd [bd, sn]"):map({
 ---  bd = "c4",
 ---  sn = "e4 #1 v0.2"
 ---})
@@ -63,8 +62,15 @@ local Cycle = {}
 ---    return { key = note + octave * 12 }
 ---  end
 ---end)
+-----Using a dynamic map function to map values to chord degrees
+---cycle("1 5 1 [6|7]"):map(function(context)
+---  local cmin = scale("c", "minor")
+---  return function(context, value)
+---    return note(cmin:chord(tonumber(value)))
+---  end
+---end)
 ---```
----@overload fun(self, function: MapFunction|MapGenerator)
+---@overload fun(self, function: CycleMapFunction|CycleMapGenerator)
 function Cycle:map(map) end
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Allows using chords in cycles:

```lua
cycle("c4'maj g4'min")
```

and allows mapping notes and/or chords via the `map` function:

```lua
cycle("a b"):map{
  a = "c4'min", 
  b = note{"c4", "d4", "g4"}:with_volume(0.5)
}
```

Part of #13

@unlessgames I ended up adding a new chord identifier/rule to the grammar instead of using the existing "name" value, as this felt super hacky. The character "'" else also isn't used in the mini notation, so that should be future proof too?

Tidal actually also supports such chord notations, but Strudel doesn't - from what I've seen.

---

~This PR isn't finished yet. I need to deal with lengths and note offs in chords correctly in the event iter impls.~
