### PR TITLE
Improve parsing performance

### DIFF
--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -112,9 +112,6 @@ mod test {
     #[test]
     fn parse() -> LuaResult<()> {
         let (lua, _) = new_test_engine()?;
-
-        assert!(evaluate_cycle_userdata(&lua, r#"cycle({})"#).is_err());
-        assert!(evaluate_cycle_userdata(&lua, r#"cycle("")"#).is_err());
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[<")"#).is_err());
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[c4 e6]")"#).is_ok());
 

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -36,12 +36,18 @@ repeat = { "!" }
 /// possible literals for single steps
 single = { hold | rest | number | chord | pitch | name }
 
-/// groups
-subdivision     = { "[" ~ (stack | split | choices | section)? ~ "]" }
-alternating     = { "<" ~ (stack | split | section)? ~ ">" }
+choice_op = {"|"}
+stack_op = {","}
+split_op = {"."}
 
-polymeter_tail  = { "%" ~  single }
-polymeter       = { "{" ~ (stack | split | section)? ~ "}" ~ polymeter_tail? }
+sections = _{ section ~ ((stack_op | split_op | choice_op) ~ section)* }
+
+/// groups
+subdivision     = { "[" ~ sections? ~ "]" }
+alternating     = { "<" ~ sections? ~ ">" }
+
+polymeter_tail  = { "%" ~  parameter }
+polymeter       = { "{" ~ sections? ~ "}" ~ polymeter_tail? }
 
 group     = _{ subdivision | alternating | polymeter }
 
@@ -66,18 +72,7 @@ expression  = { (single | group) ~ op+ }
 range       = ${ integer ~ ".." ~ integer }
 
 /// helper container that splits steps into sections
-section   = { ( expression | range | single | repeat | group)+ }
-
-/// a single choice inside a choice list
-choice    = {  expression | range | single | group }
-/// at least 2 choices, can only be inside subdivisions or the root
-choices   = { (choice) ~ ("|" ~ choice)+ }
-
-/// parallel sections of events found inside groups
-stack     = { (split | section) ~ ("," ~ (split | section))+ }
-
-// TODO shorthand for nested subdivisions
-split          = { (section) ~ ("." ~ section)+ }
+section   = _{ ( expression | range | single | repeat | group)+ }
 
 /// the root of the cycle
-mini = { SOI ~ ( stack | split | choices | section) ~ EOI }
+mini = { SOI ~ sections? ~ EOI }

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1905,6 +1905,7 @@ mod test {
 
         assert!(Cycle::from("c4'mode").is_ok());
         assert!(Cycle::from("c'm7#\u{0394}").is_ok());
+        assert!(Cycle::from("[[[[[[[[]]]]]][[[[[]][[[]]]]]][[[][[[]]]]][[[[]]]]]]").is_ok());
 
         assert_cycles(
             "<some_name _another_one c4'chord c4'-\u{0394}7 c6a_name>",


### PR DESCRIPTION
Fixes #23 

I was too lazy to benchmark and measure precisely and the pain points were fairly obvious after some quick testing. While the parser got a bit more ugly, but it's also way faster. 

Added a stress test line [here](https://github.com/emuell/afseq/commit/8530e23a1a3f8c33324c3fe9360609484dbd2631#diff-cb171cb4119158d772648040b8ba79cfc7a2788d3752f825e1c2e9015d09b6caR1908), this was hanging for a long-time before, now it doesn't.

I'm a bit bummed by the fact that utilizing the pest grammar to do the heavy-lifting leads to this much performance penalty. Maybe in the future I'll rewrite the entire parser using chumsky or combine...