### PR TITLE
use Rc<str> in cycle for all strings

### DIFF
--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -35,7 +35,7 @@ impl TryFrom<&CycleValue> for Vec<Option<NoteEvent>> {
             CycleValue::Integer(i) => Ok(vec![new_note(Note::from((*i).clamp(0, 0x7f) as u8))]),
             CycleValue::Pitch(p) => Ok(vec![new_note(Note::from(p.midi_note()))]),
             CycleValue::Chord(p, m) => {
-                let chord = Chord::try_from((p.midi_note(), m.as_str()))?;
+                let chord = Chord::try_from((p.midi_note(), m.as_ref()))?;
                 Ok(chord
                     .intervals()
                     .iter()


### PR DESCRIPTION
- should not affect parsing time, but speeds up event generation time by ~25%, as all those strings no longer need to be cloned/copied for each generated event

- ideally those strings should be string slices, pointing to the original input string, using Cow, but this really hard to realize with Rust lifetimes


@unlessgames 
This is the second most low hanging fruit after https://github.com/emuell/afseq/pull/26 (which I'm having build troubles with) and partly my "fault" as I've introduced that "string" copy in Event.  Also a good test for the PR benchmarks.

The Rc stuff isn't nice, but at least a common pattern in Rust in such cases...

Fine with me to skip this. Your decision. The performance gains are not *that* big. 
 