### PR TITLE
Perf/rhythm seeking

### DIFF
--- a/benches/benchmarks/rhythm.rs
+++ b/benches/benchmarks/rhythm.rs
@@ -191,7 +191,7 @@ pub fn run(c: &mut Criterion) {
 pub fn seek(c: &mut Criterion) {
     let mut group = c.benchmark_group("Rust Phrase");
     let phrase = create_phrase();
-    let samples_per_sec = phrase.time_base().samples_per_sec;
+    let samples_per_sec = phrase.time_base().samples_per_sec as SampleTime;
     let seek_step = 10;
     let seek_time = 60 * 60;
     group.bench_function("Seek", |b| {
@@ -202,10 +202,10 @@ pub fn seek(c: &mut Criterion) {
                 phrase
             },
             |mut phrase| {
-                let mut sample_time = samples_per_sec as SampleTime;
-                while sample_time < (seek_time * samples_per_sec) as SampleTime {
-                    phrase.skip_until_time(sample_time);
-                    sample_time += seek_step * samples_per_sec as SampleTime;
+                let mut sample_time = samples_per_sec;
+                while sample_time < seek_time * samples_per_sec {
+                    phrase.advance_until_time(sample_time);
+                    sample_time += seek_step * samples_per_sec;
                 }
             },
             criterion::BatchSize::SmallInput,

--- a/benches/benchmarks/rhythm.rs
+++ b/benches/benchmarks/rhythm.rs
@@ -204,7 +204,7 @@ pub fn seek(c: &mut Criterion) {
             |mut phrase| {
                 let mut sample_time = samples_per_sec as SampleTime;
                 while sample_time < (seek_time * samples_per_sec) as SampleTime {
-                    phrase.seek_until_time(sample_time);
+                    phrase.skip_until_time(sample_time);
                     sample_time += seek_step * samples_per_sec as SampleTime;
                 }
             },

--- a/benches/benchmarks/scripted.rs
+++ b/benches/benchmarks/scripted.rs
@@ -193,7 +193,7 @@ pub fn seek(c: &mut Criterion) {
             |mut phrase| {
                 let mut sample_time = samples_per_sec as SampleTime;
                 while sample_time < (seek_time * samples_per_sec) as SampleTime {
-                    phrase.seek_until_time(sample_time);
+                    phrase.skip_until_time(sample_time);
                     sample_time += seek_step * samples_per_sec as SampleTime;
                 }
             },

--- a/benches/benchmarks/scripted.rs
+++ b/benches/benchmarks/scripted.rs
@@ -180,7 +180,7 @@ pub fn run(c: &mut Criterion) {
 pub fn seek(c: &mut Criterion) {
     let mut group = c.benchmark_group("Scripted Phrase");
     let phrase = create_phrase();
-    let samples_per_sec = phrase.time_base().samples_per_sec;
+    let samples_per_sec = phrase.time_base().samples_per_sec as SampleTime;
     let seek_step = 10;
     let seek_time = 60 * 60;
     group.bench_function("Seek", |b| {
@@ -191,10 +191,10 @@ pub fn seek(c: &mut Criterion) {
                 phrase
             },
             |mut phrase| {
-                let mut sample_time = samples_per_sec as SampleTime;
-                while sample_time < (seek_time * samples_per_sec) as SampleTime {
-                    phrase.skip_until_time(sample_time);
-                    sample_time += seek_step * samples_per_sec as SampleTime;
+                let mut sample_time = samples_per_sec;
+                while sample_time < seek_time * samples_per_sec {
+                    phrase.advance_until_time(sample_time);
+                    sample_time += seek_step * samples_per_sec;
                 }
             },
             criterion::BatchSize::SmallInput,

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -241,12 +241,23 @@ impl LuaCallback {
             .unwrap_or("anonymous function".to_string())
     }
 
-    /// Invoke the Lua function callback or generator.
+    /// Returns true if the callback is a generator.
+    ///
+    /// To test this, the callback must have run at least once, so it returns None if it never has.
+    pub fn is_stateful(&self) -> Option<bool> {
+        if self.initialized {
+            Some(self.generator.is_some())
+        } else {
+            None
+        }
+    }
+
+    /// Invoke the Lua function or generator and return its result as LuaValue.
     pub fn call(&mut self) -> LuaResult<LuaValue> {
         self.call_with_arg(LuaValue::Nil)
     }
 
-    /// Invoke the Lua function callback or generator with an additional argument.
+    /// Invoke the Lua function or generator with an additional argument and return its result as LuaValue.
     pub fn call_with_arg<'lua, A: IntoLua<'lua> + Clone>(
         &'lua mut self,
         arg: A,

--- a/src/event.rs
+++ b/src/event.rs
@@ -395,11 +395,11 @@ pub trait EventIter: Debug {
     /// Returns an optional stack of event iter items, which should be emitted for the given pulse.
     fn run(&mut self, pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>>;
 
-    /// Move iterator with the given pulse value forward without returning an event.
+    /// Move iterator with the given pulse value forward without generating an event.
     ///
     /// This can be used to optimize iterator skipping in some EventIter implementations, but by
     /// default calls `run` and simply discards the generated event return value.
-    fn omit(&mut self, pulse: PulseIterItem, emit_event: bool) {
+    fn advance(&mut self, pulse: PulseIterItem, emit_event: bool) {
         let _ = self.run(pulse, emit_event);
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -395,7 +395,15 @@ pub trait EventIter: Debug {
     /// Returns an optional stack of event iter items, which should be emitted for the given pulse.
     fn run(&mut self, pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>>;
 
-    /// Create a new cloned instance of this event iter. This actualy is a clone(), wrapped into
+    /// Move iterator with the given pulse value forward without returning an event.
+    ///
+    /// This can be used to optimize iterator skipping in some EventIter implementations, but by
+    /// default calls `run` and simply discards the generated event return value.
+    fn omit(&mut self, pulse: PulseIterItem, emit_event: bool) {
+        let _ = self.run(pulse, emit_event);
+    }
+
+    /// Create a new cloned instance of this event iter. This actually is a clone(), wrapped into
     /// a `Box<dyn EventIter>`, but called 'duplicate' to avoid conflicts with possible
     /// Clone impls.
     fn duplicate(&self) -> Box<dyn EventIter>;

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -248,6 +248,14 @@ impl CycleEventIter {
         // convert timed note events into EventIterItems
         timed_note_events.into_event_iter_items()
     }
+
+    /// Generate next batch of events from the next cycle run but ignore the results.
+    fn omit_events(&mut self) {
+        // run the cycle event generator
+        if let Err(err) = self.cycle.omit() {
+            panic!("Cycle runtime error: {err}");
+        }
+    }
 }
 
 impl EventIter for CycleEventIter {
@@ -264,6 +272,12 @@ impl EventIter for CycleEventIter {
             Some(self.generate_events())
         } else {
             None
+        }
+    }
+
+    fn omit(&mut self, _pulse: PulseIterItem, emit_event: bool) {
+        if emit_event {
+            self.omit_events()
         }
     }
 

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -249,12 +249,9 @@ impl CycleEventIter {
         timed_note_events.into_event_iter_items()
     }
 
-    /// Generate next batch of events from the next cycle run but ignore the results.
+    /// Move the cycle event generator without generating any events
     fn omit_events(&mut self) {
-        // run the cycle event generator
-        if let Err(err) = self.cycle.omit() {
-            panic!("Cycle runtime error: {err}");
-        }
+        self.cycle.omit();
     }
 }
 

--- a/src/event/fixed.rs
+++ b/src/event/fixed.rs
@@ -107,7 +107,7 @@ impl EventIter for FixedEventIter {
         Some(vec![EventIterItem::new(event)])
     }
 
-    fn omit(&mut self, _pulse: PulseIterItem, emit_event: bool) {
+    fn advance(&mut self, _pulse: PulseIterItem, emit_event: bool) {
         if !emit_event || self.events.is_empty() {
             return;
         }

--- a/src/event/fixed.rs
+++ b/src/event/fixed.rs
@@ -103,11 +103,15 @@ impl EventIter for FixedEventIter {
             return None;
         }
         let event = self.events[self.event_index].clone();
-        self.event_index += 1;
-        if self.event_index >= self.events.len() {
-            self.event_index = 0;
-        }
+        self.event_index = (self.event_index + 1) % self.events.len();
         Some(vec![EventIterItem::new(event)])
+    }
+
+    fn omit(&mut self, _pulse: PulseIterItem, emit_event: bool) {
+        if !emit_event || self.events.is_empty() {
+            return;
+        }
+        self.event_index = (self.event_index + 1) % self.events.len();
     }
 
     fn duplicate(&self) -> Box<dyn EventIter> {

--- a/src/event/mutated.rs
+++ b/src/event/mutated.rs
@@ -73,17 +73,13 @@ impl EventIter for MutatedEventIter {
     }
 
     fn run(&mut self, _pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>> {
-        if emit_event {
-            let event = self.events[self.event_index].clone();
-            self.events[self.event_index] = Self::mutate(event.clone(), &mut self.map);
-            self.event_index += 1;
-            if self.event_index >= self.events.len() {
-                self.event_index = 0;
-            }
-            Some(vec![EventIterItem::new(event)])
-        } else {
-            None
+        if !emit_event || self.events.is_empty() {
+            return None;
         }
+        let event = self.events[self.event_index].clone();
+        self.events[self.event_index] = Self::mutate(event.clone(), &mut self.map);
+        self.event_index = (self.event_index + 1) % self.events.len();
+        Some(vec![EventIterItem::new(event)])
     }
 
     fn duplicate(&self) -> Box<dyn EventIter> {

--- a/src/event/scripted.rs
+++ b/src/event/scripted.rs
@@ -48,7 +48,7 @@ impl ScriptedEventIter {
         })
     }
 
-    fn generate_event(&mut self, pulse: PulseIterItem) -> LuaResult<Option<Vec<EventIterItem>>> {
+    fn generate(&mut self, pulse: PulseIterItem) -> LuaResult<Option<Vec<EventIterItem>>> {
         // reset timeout
         self.timeout_hook.reset();
         // update function context
@@ -65,7 +65,7 @@ impl ScriptedEventIter {
         Ok(Some(vec![EventIterItem::new(event)]))
     }
 
-    fn omit_event(&mut self, pulse: PulseIterItem) -> LuaResult<()> {
+    fn advance(&mut self, pulse: PulseIterItem) -> LuaResult<()> {
         if self.callback.is_stateful().unwrap_or(true) {
             // reset timeout
             self.timeout_hook.reset();
@@ -116,7 +116,7 @@ impl EventIter for ScriptedEventIter {
     fn run(&mut self, pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>> {
         // generate a new event and move or only update pulse counters
         if emit_event {
-            let event = match self.generate_event(pulse) {
+            let event = match self.generate(pulse) {
                 Ok(event) => event,
                 Err(err) => {
                     self.callback.handle_error(&err);
@@ -134,10 +134,10 @@ impl EventIter for ScriptedEventIter {
         }
     }
 
-    fn omit(&mut self, pulse: PulseIterItem, emit_event: bool) {
+    fn advance(&mut self, pulse: PulseIterItem, emit_event: bool) {
         // generate a new event and move or only update pulse counters
         if emit_event {
-            if let Err(err) = self.omit_event(pulse) {
+            if let Err(err) = self.advance(pulse) {
                 self.callback.handle_error(&err);
             }
             self.step += 1;

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -171,12 +171,9 @@ impl ScriptedCycleEventIter {
         timed_note_events.into_event_iter_items()
     }
 
-    /// Generate next batch of events from the next cycle run but ignore the results.
+    /// Move the cycle event generator without generating any events
     fn omit_events(&mut self) {
-        // run the cycle event generator
-        if let Err(err) = self.cycle.omit() {
-            add_lua_callback_error("cycle", &LuaError::RuntimeError(err));
-        }
+        self.cycle.omit();
     }
 }
 

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -170,6 +170,14 @@ impl ScriptedCycleEventIter {
         // convert timed note events into EventIterItems
         timed_note_events.into_event_iter_items()
     }
+
+    /// Generate next batch of events from the next cycle run but ignore the results.
+    fn omit_events(&mut self) {
+        // run the cycle event generator
+        if let Err(err) = self.cycle.omit() {
+            add_lua_callback_error("cycle", &LuaError::RuntimeError(err));
+        }
+    }
 }
 
 impl EventIter for ScriptedCycleEventIter {
@@ -200,6 +208,12 @@ impl EventIter for ScriptedCycleEventIter {
             Some(self.generate_events())
         } else {
             None
+        }
+    }
+
+    fn omit(&mut self, _pulse: PulseIterItem, emit_event: bool) {
+        if emit_event {
+            self.omit_events()
         }
     }
 

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -128,7 +128,7 @@ impl ScriptedCycleEventIter {
 
     /// Generate next batch of events from the next cycle run.
     /// Converts cycle events to note events and flattens channels into note columns.
-    fn generate_events(&mut self) -> Vec<EventIterItem> {
+    fn generate(&mut self) -> Vec<EventIterItem> {
         // run the cycle event generator
         let events = {
             match self.cycle.generate() {
@@ -170,11 +170,6 @@ impl ScriptedCycleEventIter {
         // convert timed note events into EventIterItems
         timed_note_events.into_event_iter_items()
     }
-
-    /// Move the cycle event generator without generating any events
-    fn omit_events(&mut self) {
-        self.cycle.omit();
-    }
 }
 
 impl EventIter for ScriptedCycleEventIter {
@@ -202,15 +197,15 @@ impl EventIter for ScriptedCycleEventIter {
 
     fn run(&mut self, _pulse: PulseIterItem, emit_event: bool) -> Option<Vec<EventIterItem>> {
         if emit_event {
-            Some(self.generate_events())
+            Some(self.generate())
         } else {
             None
         }
     }
 
-    fn omit(&mut self, _pulse: PulseIterItem, emit_event: bool) {
+    fn advance(&mut self, _pulse: PulseIterItem, emit_event: bool) {
         if emit_event {
-            self.omit_events()
+            self.cycle.advance();
         }
     }
 

--- a/src/phrase.rs
+++ b/src/phrase.rs
@@ -115,8 +115,8 @@ impl Phrase {
         }
     }
 
-    /// Seek rhythms until a given sample time is reached, ignoring all events until that time.
-    pub fn skip_events_until_time(&mut self, sample_time: SampleTime) {
+    /// Move rhythms until a given sample time is reached, ignoring all events until that time.
+    pub fn advance_until_time(&mut self, sample_time: SampleTime) {
         // skip next events in all rhythms
         for (rhythm_slot, next_event) in self
             .rhythm_slots
@@ -126,13 +126,13 @@ impl Phrase {
             // skip cached, next due events
             if let Some((_, event)) = next_event {
                 if event.time >= sample_time {
-                    // cached event is not yet due: no need to seek the slot
+                    // cached event is not yet due: no need to advance the slot
                     continue;
                 }
                 *next_event = None;
             }
             if let RhythmSlot::Rhythm(rhythm) = rhythm_slot {
-                rhythm.borrow_mut().skip_until_time(sample_time);
+                rhythm.borrow_mut().advance_until_time(sample_time);
             }
         }
     }
@@ -246,8 +246,8 @@ impl RhythmIter for Phrase {
             .map(|(_, event)| event)
     }
 
-    fn skip_until_time(&mut self, sample_time: SampleTime) {
-        self.skip_events_until_time(sample_time)
+    fn advance_until_time(&mut self, sample_time: SampleTime) {
+        self.advance_until_time(sample_time)
     }
 }
 
@@ -469,8 +469,8 @@ mod test {
     }
 
     // fast skip using skip_events_until_time
-    fn skip_phrase_by_omitting(phrase: &mut Phrase, time: SampleTime) {
-        phrase.skip_events_until_time(time)
+    fn skip_phrase_by_advancing(phrase: &mut Phrase, time: SampleTime) {
+        phrase.advance_until_time(time)
     }
 
     #[test]
@@ -485,7 +485,7 @@ mod test {
         phrase2.set_sample_offset(sample_offset);
         let mut events2 = Vec::new();
 
-        // run_time, seek_time
+        // run_time, advance_time
         let run_steps = [
             (1024, 1),
             (2000, 555432),
@@ -507,7 +507,7 @@ mod test {
 
             sample_time += seek_time;
             skip_phrase_by_running(&mut phrase1, sample_time);
-            skip_phrase_by_omitting(&mut phrase2, sample_time);
+            skip_phrase_by_advancing(&mut phrase2, sample_time);
         }
 
         assert_eq!(events1, events2);

--- a/src/player.rs
+++ b/src/player.rs
@@ -236,10 +236,10 @@ impl SamplePlayer {
             // match playing notes state to the passed rhythm
             self.playing_notes
                 .resize(sequence.phrase_rhythm_slot_count(), HashMap::new());
-            // seek new phase to our previously played time
-            sequence.skip_events_until_time(self.emitted_sample_time);
+            // move new phase to our previously played time
+            sequence.advance_until_time(self.emitted_sample_time);
             log::debug!(target: "Player",
-                "Seek sequence to time {:.2}",
+                "Advance sequence to time {:.2}",
                 time_base.samples_to_seconds(self.emitted_sample_time)
             );
         }

--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -70,12 +70,13 @@ pub trait RhythmIter: Debug {
     /// event from the event iter and returns it. Else returns `None` when the pattern finished playing.
     fn run_until_time(&mut self, sample_time: SampleTime) -> Option<RhythmIterItem>;
 
-    /// Skip, dry run *all events* until the given target time is reached. Depending on the rhythm
-    /// impl this may be faster than using `run_until_time`, fetching, then discarding events.
-    fn seek_until_time(&mut self, sample_time: SampleTime) {
-        // default impl fetches and ignores all events until we've reached the given sample_time
-        while let Some(event) = self.run_until_time(sample_time) {
-            debug_assert!(event.time < sample_time);
+    /// Skip, dry run *all events* until the given target time is reached.
+    ///
+    /// This calls `run_until_time` by default, until the target time is reached and
+    /// discards all generated events, but may be overridden to optimize run time.
+    fn skip_until_time(&mut self, sample_time: SampleTime) {
+        while self.run_until_time(sample_time).is_some() {
+            // continue
         }
     }
 }

--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -60,21 +60,18 @@ pub trait RhythmIter: Debug {
     /// Set a new custom sample offset value.
     fn set_sample_offset(&mut self, sample_offset: SampleTime);
 
-    /// Step iter: runs pattern to generate a new pulse, then generates an event from the event iter.
-    /// Returns `None` when the pattern finished playing.
-    fn run(&mut self) -> Option<RhythmIterItem> {
-        self.run_until_time(SampleTime::MAX)
-    }
-    /// Sample time iter: Generates the next due event but running the pattern to generate a new
+    /// Sample time iter: Generate a single next due event but running the pattern to generate a new
     /// pulse, if the pulse's sample time is smaller than the given sample time. Then generates an
-    /// event from the event iter and returns it. Else returns `None` when the pattern finished playing.
+    /// event from the event iter and returns it.
+    ///
+    /// Returns `None` when no event is due of when the pattern finished playing, else Some event.
     fn run_until_time(&mut self, sample_time: SampleTime) -> Option<RhythmIterItem>;
 
-    /// Skip, dry run *all events* until the given target time is reached.
+    /// Skip *all events* until the given target time is reached.
     ///
     /// This calls `run_until_time` by default, until the target time is reached and
     /// discards all generated events, but may be overridden to optimize run time.
-    fn skip_until_time(&mut self, sample_time: SampleTime) {
+    fn advance_until_time(&mut self, sample_time: SampleTime) {
         while self.run_until_time(sample_time).is_some() {
             // continue
         }
@@ -88,7 +85,7 @@ impl Iterator for dyn RhythmIter {
     type Item = RhythmIterItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.run()
+        self.run_until_time(SampleTime::MAX)
     }
 }
 

--- a/src/rhythm/beat_time.rs
+++ b/src/rhythm/beat_time.rs
@@ -9,16 +9,19 @@ use crate::{
 // -------------------------------------------------------------------------------------------------
 
 impl GenericRhythmTimeStep for BeatTimeStep {
+    #[inline]
     fn default_offset() -> Self {
         Self::Beats(0.0)
     }
 
+    #[inline]
     fn default_step() -> Self {
         Self::Beats(1.0)
     }
 
-    fn to_samples(&self, time_base: &crate::BeatTimeBase) -> f64 {
-        self.to_samples(time_base)
+    #[inline]
+    fn to_samples(&self, time_base: &BeatTimeBase) -> f64 {
+        BeatTimeStep::to_samples(self, time_base)
     }
 }
 

--- a/src/rhythm/generic.rs
+++ b/src/rhythm/generic.rs
@@ -181,11 +181,13 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> GenericRhythm<S
     }
 
     /// Return current pulse duration in samples
+    #[inline]
     pub fn current_steps_sample_duration(&self) -> f64 {
         self.step.to_samples(&self.time_base) * self.event_iter_pulse_item.step_time
     }
 
     /// Return start sample time of the given event iter item
+    #[inline]
     fn event_iter_item_start_time(&self, start: &Fraction) -> SampleTime {
         let step_time = self.current_steps_sample_duration();
         let event_iter_time = self.sample_offset as f64 + self.event_iter_next_sample_time;
@@ -194,6 +196,7 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> GenericRhythm<S
     }
 
     /// Return duration in sample time of the given event iter item
+    #[inline]
     fn event_iter_item_duration(&self, length: &Fraction) -> SampleTime {
         let step_time = self.current_steps_sample_duration();
         let length = length.to_f64().unwrap_or(1.0);

--- a/src/rhythm/second_time.rs
+++ b/src/rhythm/second_time.rs
@@ -10,16 +10,19 @@ use crate::{
 // -------------------------------------------------------------------------------------------------
 
 impl GenericRhythmTimeStep for SecondTimeStep {
+    #[inline]
     fn default_offset() -> Self {
         0.0
     }
 
+    #[inline]
     fn default_step() -> Self {
         1.0
     }
 
+    #[inline]
     fn to_samples(&self, time_base: &BeatTimeBase) -> f64 {
-        time_base.seconds_to_samples_exact(*self)
+        *self * time_base.samples_per_second() as f64
     }
 }
 

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -116,9 +116,7 @@ impl Cycle {
     }
 
     /// Move cycle iteration without generating any events.
-    ///
-    /// This simply moves the cycle iteration count.
-    pub fn omit(&mut self) {
+    pub fn advance(&mut self) {
         self.state.iteration += 1;
     }
 
@@ -1734,14 +1732,14 @@ mod test {
         Ok(())
     }
 
-    fn assert_cycle_seeking(input: &str) -> Result<(), String> {
+    fn assert_cycle_advancing(input: &str) -> Result<(), String> {
         let seed = rand::thread_rng().gen();
-        for number_of_seeks in 1..9 {
+        for number_of_runs in 1..9 {
             let mut cycle1 = Cycle::from(input)?.with_seed(seed);
             let mut cycle2 = Cycle::from(input)?.with_seed(seed);
-            for _ in 0..number_of_seeks {
+            for _ in 0..number_of_runs {
                 let _ = cycle1.generate()?;
-                cycle2.omit();
+                cycle2.advance();
             }
             assert_eq!(cycle1.generate()?, cycle2.generate()?);
         }
@@ -2209,15 +2207,15 @@ mod test {
     }
 
     #[test]
-    fn seeking() -> Result<(), String> {
-        assert_cycle_seeking("[a b c d]")?; // stateless
-        assert_cycle_seeking("[a b], [c d]")?;
-        assert_cycle_seeking("{a b}%2 {a b}*5")?; // stateful
-        assert_cycle_seeking("[a b]*5 [a b]/5")?;
-        assert_cycle_seeking("[a b c d]<c d>")?;
-        assert_cycle_seeking("a <b c>")?;
-        assert_cycle_seeking("[a b? c d]|[c? d?]")?;
-        assert_cycle_seeking("[{a b}/2 c d], <c d> e? {a b}*2")?;
+    fn advancing() -> Result<(), String> {
+        assert_cycle_advancing("[a b c d]")?; // stateless
+        assert_cycle_advancing("[a b], [c d]")?;
+        assert_cycle_advancing("{a b}%2 {a b}*5")?; // stateful
+        assert_cycle_advancing("[a b]*5 [a b]/5")?;
+        assert_cycle_advancing("[a b c d]<c d>")?;
+        assert_cycle_advancing("a <b c>")?;
+        assert_cycle_advancing("[a b? c d]|[c? d?]")?;
+        assert_cycle_advancing("[{a b}/2 c d], <c d> e? {a b}*2")?;
         Ok(())
     }
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,7 +36,4 @@ pub trait TimeBase: Debug {
     fn seconds_to_samples(&self, seconds: f64) -> SampleTime {
         (seconds * self.samples_per_second() as f64).trunc() as SampleTime
     }
-    fn seconds_to_samples_exact(&self, seconds: f64) -> f64 {
-        seconds * self.samples_per_second() as f64
-    }
 }

--- a/src/time/beats.rs
+++ b/src/time/beats.rs
@@ -15,10 +15,12 @@ pub struct BeatTimeBase {
 
 impl BeatTimeBase {
     /// Time base's samples per beat, in order to convert beat to sample time and vice versa.
+    #[inline]
     pub fn samples_per_beat(&self) -> f64 {
         self.samples_per_sec as f64 * 60.0 / self.beats_per_min as f64
     }
     /// Time base's samples per bar, in order to convert bar to sample time and vice versa.
+    #[inline]
     pub fn samples_per_bar(&self) -> f64 {
         self.samples_per_sec as f64 * 60.0 / self.beats_per_min as f64 * self.beats_per_bar as f64
     }
@@ -33,6 +35,7 @@ impl From<BeatTimeBase> for SecondTimeBase {
 }
 
 impl TimeBase for BeatTimeBase {
+    #[inline]
     fn samples_per_second(&self) -> u32 {
         self.samples_per_sec
     }
@@ -43,10 +46,10 @@ impl SampleTimeDisplay for BeatTimeBase {
     fn display(&self, sample_time: SampleTime) -> String {
         let total_beats = sample_time / self.samples_per_beat() as u64;
         let total_beats_f = sample_time as f64 / self.samples_per_beat();
-        let beat_frations = total_beats_f - total_beats as f64;
+        let beat_fractions = total_beats_f - total_beats as f64;
         let bars = total_beats / self.beats_per_bar as u64;
         let beats = total_beats - self.beats_per_bar as u64 * bars;
-        let ppq = (beat_frations * 960.0 + 0.5) as u64;
+        let ppq = (beat_fractions * 960.0 + 0.5) as u64;
         format!("{}.{}.{:03}", bars + 1, beats + 1, ppq)
     }
 }
@@ -69,7 +72,6 @@ pub enum BeatTimeStep {
 impl BeatTimeStep {
     /// Get number of steps in the current time resolution.
     pub fn steps(&self) -> f32 {
-        #[allow(clippy::match_same_arms)]
         match *self {
             BeatTimeStep::SixtyFourth(amount) => amount,
             BeatTimeStep::ThirtySecond(amount) => amount,
@@ -109,6 +111,7 @@ impl BeatTimeStep {
         }
     }
     /// Convert a beat or bar step to samples for the given beat time base.
+    #[inline]
     pub fn to_samples(&self, time_base: &BeatTimeBase) -> f64 {
         self.steps() as f64 * self.samples_per_step(time_base)
     }

--- a/src/time/seconds.rs
+++ b/src/time/seconds.rs
@@ -12,6 +12,7 @@ pub struct SecondTimeBase {
 }
 
 impl TimeBase for SecondTimeBase {
+    #[inline]
     fn samples_per_second(&self) -> u32 {
         self.samples_per_sec
     }


### PR DESCRIPTION
Speed up rhythm/phrase seeking. See https://github.com/emuell/afseq/issues/6

* when seeking phrases & rhythms batch process event iteration where possible
 
* try avoiding as much processing as possible while seeking, by using new "omit" event iter functions and cycle processing functions, which only maintain internal event iter state without actually computing events.

This is WIP, and already ~2x faster in many cases, but unfortunately still not fast enough. Ideal would be speedups of ~8x in normal processing vs seeking. When live editing phrase scripts, the seek function is called quite often for quite long periods of time (minutes up to hours). So this is very performance critical. 

@unlessgames As mentioned above, I've also added a new "omit" function to Cycle, but the implementation is rather ugly, but maybe still better than duplicating the whole "output" function for seeking. In general, anything that can be skipped should be skipped there - without breaking the internal state across cycle passes. To make this easier to check, I've added some tests for this, and also reorganised the tests to separate the seek tests from the others. 
See especially this change here:  https://github.com/emuell/afseq/commit/774fde627423af171b7329c1ac20eb2c757cc956

You may have some better ideas on how to fix or improve this.

PS: Omit is quite a shitty name for this, but unfortunately "skip" clashes with the standard Rust Iterator impls. I'll clean this skip vs seek vs omit wording after this PR is merged. This will change things across the whole repository. This PR already now is too big.

I'll now concentrate on optimising the other parts of the rhythms: generator patterns, emitters.