### PR TITLE
build and cache mdbook instead of using cargo binstall

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with: 
           cache-workspaces: "docs"
+          cache-key: "afseq-pages"
 
-      - name: Install binstall
-        uses: cargo-bins/cargo-binstall@main
-        
       - name: Install mdbook
-        run: cargo binstall -y mdbook mdbook-linkcheck mdbook-toc mdbook-alerts
-  
+        run: cargo install mdbook mdbook-linkcheck mdbook-toc mdbook-alerts
+
       - name: Generate API
         run: cd docs && cargo run
 


### PR DESCRIPTION
- fixes mdbook errors in github runners