### PR TITLE
fix cycle number parsing issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ mlua = { version = "^0.10", default-features = false, features = [
 ], optional = true }
 
 [dev-dependencies]
+pretty_assertions = "^1.4"
 notify = { version = "^8.0" }
 ctrlc = { version = "^3.4" }
 criterion = { version = "^0.5" }

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -5,12 +5,10 @@
 WHITESPACE = _{ " " | "\t" | "\u{A0}" | NEWLINE }
 
 /// numbers types allowing [ "1" "1.0" "1." ".1" ]
-digit   = @{("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)}
+digit   = _{("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)}
 integer = @{ "-"? ~ digit}
-normal  = @{ "-"? ~ "." ~ digit }
-float   = @{ "-"? ~ digit ~ "." ~ (digit)* }
-// exp           = _{ ^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+ }
-number  = ${ (normal | float | integer) ~ !(ASCII_ALPHA) }
+float   = @{ "-"? ~ (digit ~ "." ~ ASCII_DIGIT*) | ("." ~ ASCII_DIGIT+) }
+number  = ${ (float | integer) ~ !(ASCII_ALPHA) }
 
 /// case-insensitive pitch type with note, optional octave and sharp or flat mark
 octave  = { "10" | ASCII_DIGIT }

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1053,16 +1053,12 @@ impl CycleParser {
     fn value(pair: Pair<Rule>) -> Result<Value, String> {
         match pair.as_rule() {
             Rule::integer => Ok(Value::Integer(pair.as_str().parse::<i32>().unwrap_or(0))),
-            Rule::float | Rule::normal => {
-                Ok(Value::Float(pair.as_str().parse::<f64>().unwrap_or(0.0)))
-            }
+            Rule::float => Ok(Value::Float(pair.as_str().parse::<f64>().unwrap_or(0.0))),
             Rule::number => {
                 if let Some(n) = pair.into_inner().next() {
                     match n.as_rule() {
                         Rule::integer => Ok(Value::Integer(n.as_str().parse::<i32>().unwrap_or(0))),
-                        Rule::float | Rule::normal => {
-                            Ok(Value::Float(n.as_str().parse::<f64>().unwrap_or(0.0)))
-                        }
+                        Rule::float => Ok(Value::Float(n.as_str().parse::<f64>().unwrap_or(0.0))),
                         _ => Err(format!("unrecognized number\n{:?}", n)),
                     }
                 } else {
@@ -1946,6 +1942,18 @@ mod test {
 
     #[test]
     fn generate() -> Result<(), String> {
+        assert_eq!(
+            Cycle::from("[0] [1] [1.01] [0.01] [0.] [.01]")?.generate()?,
+            [[
+                Event::at(F::new(0u8, 6u8), F::new(1u8, 6u8)).with_int(0),
+                Event::at(F::new(1u8, 6u8), F::new(1u8, 6u8)).with_int(1),
+                Event::at(F::new(2u8, 6u8), F::new(1u8, 6u8)).with_float(1.01),
+                Event::at(F::new(3u8, 6u8), F::new(1u8, 6u8)).with_float(0.01),
+                Event::at(F::new(4u8, 6u8), F::new(1u8, 6u8)).with_float(0.0),
+                Event::at(F::new(5u8, 6u8), F::new(1u8, 6u8)).with_float(0.01),
+            ]]
+        );
+
         assert_eq!(Cycle::from("a*[]")?.generate()?, [[]]);
         assert_eq!(
             Cycle::from("a b c d")?.generate()?,

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1876,6 +1876,8 @@ impl Cycle {
 mod test {
     use super::*;
 
+    use pretty_assertions::assert_eq;
+
     type F = fraction::Fraction;
 
     fn assert_cycles(input: &str, outputs: Vec<Vec<Vec<Event>>>) -> Result<(), String> {


### PR DESCRIPTION
expressions such as `.01` got parsed as float number with an additional integer number

See https://pest.rs/?g=N4Ig5gTghgtjURALhAenQAgHYFcYCMBTCAZwwBcBPAB0LKgBsGB7AdwEsswMBtDAHRABGQQOEA6AAyjBQ8TJDiRIDAF1%2BWACbsw7chgMBeDAAFgACkHSVAHwwBBAMoBhAJKuA%2BgDkA8l4BaAKIASj4eACKuAOKuACoYAH4OLu4R0XEAVACUAL4anOSEYMQYxmZiALSCAPyJGNq65HlYWMwQ8AxGpsCVNXWC8ipJDXoYzQBmLFD6XeWCVSC1wzqjSQOiSeYj5FkZYxqYhAAe1AZn510ePQB6goQbGJYgANSidvOCWUvJbp6RMbFnvsWngiBAugASHrmVrtRgYOyTZjTBEYApFYhZOoAQnMTl%2BHnsABkAAoACXsWJyIAANCBONQcORkIpJEIAEy0kAkQgMQgAY0KmmCOD5LNwBGIIByQA#editor

also added pretty_assertion to ease debugging cycle tests a bit

Stumbled upon this while working on https://github.com/emuell/afseq/issues/31 