### PR TITLE
cycle target chaining & note attributes

### DIFF
--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -11,7 +11,8 @@
 > 
 > `cycle` accepts a mini-notation as used by Tidal Cycles, with the following differences:
 > * Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
-> * `:` sets the instrument or remappable target instead of selecting samples
+> * `:` sets the instrument or remappable target instead of selecting samples but also 
+>   allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 > * In bjorklund expressions, operators *within* and on the *right side* are not supported
 >   (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
 > 

--- a/docs/src/guide/cycles.md
+++ b/docs/src/guide/cycles.md
@@ -20,7 +20,7 @@ There's no exact specification for how tidal cycles work, and it's constantly ev
 
 * Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
 
-* `:` sets the instrument or remappable target instead of selecting samples
+* `:` sets the instrument or remappable target instead of selecting samples but also allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 
 * In bjorklund expressions, operators *within* and on the *right side* are not supported (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
 
@@ -74,6 +74,29 @@ return cycle "c4 d4 g4|a4"
 
 afseq's general random number generator is also used in cycles. So when you seed the global number generator, you can also seed the cycle's random operations with `math.randomseed(12345)`.  
 
+### Note Attributes
+
+You can set note attributes in cycle patterns using chained `:` expressions:
+
+```lua
+-- Set instrument (2), panning (-0.5), and delay (0.25)
+cycle("d4:2:p-0.5:d0.25")
+
+-- Set instrument (1) with alternating volumes (0.1, 0.2)
+cycle("c4:1:<v0.1 v0.2>")
+
+-- Set multiple attributes with randomization
+cycle("c4:[v0.5:d0.1|v0.8]")
+```
+
+Supported note attributes are:
+- Instrument: `:#X` - same as `:X`, without the `#`
+- Volume: `:vX` - with X \[0.0-1.0\]
+- Panning: `:pX` - with X \[-1.0 to 1.0\] 
+- Delay: `:dX` - with X \[0.0-1.0\)
+
+Note that `X` must be written as *floating point number* for volume, panning and delay:</br> `c4:p-1.0` and `c4:p.8` is valid, while `c4:p-1` **is not valid**!
+
 
 ### Mapping
 
@@ -121,6 +144,12 @@ A polyrhythm
 
 ```lua
 return cycle("[C3 D#4 F3 G#4], [[D#3?0.2 G4 F4]/64]*63")
+```
+
+Alternate panning with note attributes
+
+```lua
+cycle("c4:<p-0.5 p.00 p0.5>")
 ```
 
 Mapped multi channel beats

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -153,6 +153,23 @@ mod test {
             ])
         );
 
+        // check note properties
+        let mapped_cycle = evaluate_cycle_userdata(&lua, r#"cycle("a:1:v0.1:p-1.0:d0.3")"#)?;
+        let mut event_iter =
+            CycleEventIter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+        assert_eq!(
+            event_iter
+                .run(PulseIterItem::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![Event::NoteEvents(vec![new_note((
+                Note::A4,
+                InstrumentId::from(1),
+                0.1,
+                -1.0,
+                0.3
+            ))]),])
+        );
+
         // check instrument overrides
         let mapped_cycle = evaluate_cycle_userdata(
             &lua,
@@ -170,6 +187,24 @@ mod test {
                 Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(66)))])
             ])
         );
+
+        // check note property overrides
+        let mapped_cycle = evaluate_cycle_userdata(
+            &lua,
+            r#"cycle("a:1:v.1 a"):map({ a = { key = 48, instrument = 66, volume = 1.0 } })"#,
+        )?;
+        let mut event_iter =
+            CycleEventIter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+        assert_eq!(
+            event_iter
+                .run(PulseIterItem::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![
+                Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(1), 0.1))]),
+                Event::NoteEvents(vec![new_note((Note::C4, InstrumentId::from(66), 1.0))])
+            ])
+        );
+
         Ok(())
     }
 

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -202,10 +202,12 @@ impl CycleEventIter {
             }
         };
         // inject target instrument, if present
-        if let Some(instrument) = event.target().into() {
-            for mut note_event in &mut note_events {
-                if let Some(note_event) = &mut note_event {
-                    note_event.instrument = Some(instrument);
+        if let Some(target) = event.targets().first() {
+            if let Some(instrument) = target.into() {
+                for mut note_event in &mut note_events {
+                    if let Some(note_event) = &mut note_event {
+                        note_event.instrument = Some(instrument);
+                    }
                 }
             }
         }

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -119,10 +119,12 @@ impl ScriptedCycleEventIter {
             )));
         }
         // inject target instrument, if present
-        if let Some(instrument) = event.target().into() {
-            for mut note_event in &mut note_events {
-                if let Some(note_event) = &mut note_event {
-                    note_event.instrument = Some(instrument);
+        if let Some(target) = event.targets().first() {
+            if let Some(instrument) = target.into() {
+                for mut note_event in &mut note_events {
+                    if let Some(note_event) = &mut note_event {
+                        note_event.instrument = Some(instrument);
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,9 @@ pub use event::{
 
 pub mod tidal;
 pub use tidal::{
-    Cycle, Event as CycleEvent, Span as CycleSpan, Target as CycleTarget, Value as CycleValue,
+    Cycle, Event as CycleEvent, PropertyKey as CyclePropertyKey,
+    PropertyValue as CyclePropertyValue, Span as CycleSpan, Target as CycleTarget,
+    Value as CycleValue,
 };
 
 pub mod pulse;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,6 +27,8 @@ pub use super::{
     Chord,
     Cycle,
     CycleEvent,
+    CyclePropertyKey,
+    CyclePropertyValue,
     CycleSpan,
     CycleTarget,
     CycleValue,

--- a/src/tidal.rs
+++ b/src/tidal.rs
@@ -1,4 +1,4 @@
 //! Tidal mini parser and event generator, used as `EventIter`.
 
 mod cycle;
-pub use cycle::{Cycle, Event, Pitch, Span, Target, Value};
+pub use cycle::{Cycle, Event, Pitch, PropertyKey, PropertyValue, Span, Target, Value};

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -56,23 +56,23 @@ op_replicate = ${ "!" ~ number }
 op_weight    = ${ "@" ~ number? }
 op_degrade   = ${ "?" ~ number? }
 
-/// dynamic operators
+/// dynamic operators (only o_target can be chained)
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
-op_target    = { ":" ~ parameter }
+op_target    = { ":" ~ parameter ~ (":" ~ parameter)* }
 
 // this should actually be parameter as well 
 // once bjorklund with patterns on the right is implemented
 single_parameter = _{ single }
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 
-op           = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
+op = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
 
-expression  = { (single | group) ~ op+ }
-range       = ${ integer ~ ".." ~ integer }
+expression = { (single | group) ~ op+ }
+range = ${ integer ~ ".." ~ integer }
 
 /// helper container that splits steps into sections
-section   = _{ ( expression | range | single | repeat | group)+ }
+section = _{ ( expression | range | single | repeat | group)+ }
 
 /// the root of the cycle
 mini = { SOI ~ sections? ~ EOI }

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -15,6 +15,9 @@ mark    = { "#"|"b" }
 note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
 pitch   = ${ note ~ mark? ~ octave? ~ !name}
 
+// target properties such as volume "v0.1" (afseq extension)
+property = ${ ("#" ~ integer) | (ASCII_ALPHA ~ float) }
+
 /// chord as pitch with mode string, separated via "'"
 mode    = ${ (ASCII_ALPHANUMERIC | "#" | "-" | "+" | "^")+ }
 chord   = ${ pitch ~ "'" ~ mode }
@@ -31,7 +34,7 @@ name = @{ (ASCII_ALPHANUMERIC | "_")+ }
 repeat = { "!" }
 
 /// possible literals for single steps
-single = { hold | rest | number | chord | pitch | name }
+single = { hold | rest | chord | property | pitch | number | name }
 
 choice_op = {"|"}
 stack_op = {","}
@@ -46,33 +49,31 @@ alternating     = { "<" ~ sections? ~ ">" }
 polymeter_tail  = { "%" ~  parameter }
 polymeter       = { "{" ~ sections? ~ "}" ~ polymeter_tail? }
 
-group     = _{ subdivision | alternating | polymeter }
+group           = _{ subdivision | alternating | polymeter }
 
 /// parameter for expressions with operators
-parameter = _{ expression | single | group }
+parameter        = _{ expression | single | group }
+single_parameter = _{ single }
 
 /// static operators
 op_replicate = ${ "!" ~ number }
 op_weight    = ${ "@" ~ number? }
 op_degrade   = ${ "?" ~ number? }
 
-/// dynamic operators (only o_target can be chained)
+/// dynamic operators (NB: only o_target can be chained)
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
 op_target    = { ":" ~ parameter ~ (":" ~ parameter)* }
-
-// this should actually be parameter as well 
-// once bjorklund with patterns on the right is implemented
-single_parameter = _{ single }
+// this should actually use `parameter` as well once bjorklund with patterns on the right is implemented
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 
-op = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
+/// all operators
+op           = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
 
 expression = { (single | group) ~ op+ }
-range = ${ integer ~ ".." ~ integer }
-
+range      = ${ integer ~ ".." ~ integer }
 /// helper container that splits steps into sections
-section = _{ ( expression | range | single | repeat | group)+ }
+section    = _{ ( expression | range | single | repeat | group)+ }
 
 /// the root of the cycle
 mini = { SOI ~ sections? ~ EOI }

--- a/types/nerdo/library/cycle.lua
+++ b/types/nerdo/library/cycle.lua
@@ -91,7 +91,8 @@ function Cycle:map(map) end
 ---
 ---`cycle` accepts a mini-notation as used by Tidal Cycles, with the following differences:
 ---* Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
----* `:` sets the instrument or remappable target instead of selecting samples
+---* `:` sets the instrument or remappable target instead of selecting samples but also 
+---  allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 ---* In bjorklund expressions, operators *within* and on the *right side* are not supported
 ---  (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
 ---


### PR DESCRIPTION
fixes https://github.com/emuell/afseq/issues/31
requires https://github.com/emuell/afseq/pull/53

- allows chaining `:` expressions
- allows setting note attributes (instrument/volume/pan/delay) via targets

Example:
```lua
cycle("c4:1:<v0.1 v0.2>") -- play c4 with instr. 1, volume 0.1, then 0.2
```

@unlessgames 
I originally did not want to add a `pitch_property' to the grammar, but it was needed to distinguish the note attributes from pitch literals. `d1` could be a pitch or a delay attribute. That's why I only allow floats as number values in the attributes, and do match `pitch_property` before `pitch` in the grammar. 

Ideally `op_target` should only allow a subset of parameters as parameter. But that would require duplicating a lot of the existing rules just to narrow things down for the target parameter. I don't think it's worth it, but maybe you have another idea how to solve this more elegantly.

Also, `pitch_property` is not parsed in the cycle parser, but is passed as a target string and then parsed in the cycle event iter trait. I don't have a strong opinion on which is the better place to parse it.

TODOs:

- [x]  update docs (examples, guides and API) 