### PR TITLE
Cycle event generation performance tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ log = { version = "^0.4" }
 simplelog = { version = "^0.12" }
 rand = { version = "^0.9" }
 rand_xoshiro = { version = "^0.7" }
-fraction = { version = "^0.15" }
+num-rational = { version = "^0.4", default-features = false, features = ["std"] }
+num-traits = { version = "^0.2", default-features = false, features = ["std"] }
 pest = { version = "^2.7" }
 pest_derive = { version = "^2.7" }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{BeatTimeBase, InputParameterSet, Note, PulseIterItem};
 use fixed::{FixedEventIter, ToFixedEventIter, ToFixedEventIterSequence};
 
-use fraction::{ConstOne, ConstZero, Fraction};
+type Fraction = num_rational::Rational32;
 
 // -------------------------------------------------------------------------------------------------
 

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::HashMap, ops::RangeBounds};
 
-use fraction::Fraction;
+type Fraction = num_rational::Rational32;
 
 use crate::{
     event::new_note, BeatTimeBase, Chord, Cycle, CycleEvent, CyclePropertyKey, CyclePropertyValue,

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
-use fraction::ToPrimitive;
+use num_traits::ToPrimitive;
+
 use mlua::prelude::{LuaError, LuaResult};
 
 use crate::{

--- a/src/rhythm/generic.rs
+++ b/src/rhythm/generic.rs
@@ -8,7 +8,8 @@ use std::{
     rc::Rc,
 };
 
-use fraction::{ConstOne, ConstZero, Fraction, ToPrimitive};
+type Fraction = num_rational::Rational32;
+use num_traits::ToPrimitive;
 
 #[cfg(all(feature = "scripting", test))]
 use std::borrow::BorrowMut;

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -897,7 +897,7 @@ impl Events {
     {
         match self {
             Events::Multi(m) => {
-                let mut filtered = vec![];
+                let mut filtered = Vec::with_capacity(m.events.len());
                 for e in &mut m.events {
                     match e {
                         Events::Single(s) => {
@@ -916,7 +916,7 @@ impl Events {
                 !m.events.is_empty()
             }
             Events::Poly(p) => {
-                let mut filtered = vec![];
+                let mut filtered = Vec::with_capacity(p.channels.len());
                 for e in &mut p.channels {
                     if e.filter_mut(predicate) {
                         filtered.push(e.clone())
@@ -1324,7 +1324,7 @@ impl CycleParser {
 
     fn section_vec(pairs: Vec<Pair<Rule>>) -> Result<Vec<Step>, String> {
         let choiced_steps = Self::with_choices(pairs)?;
-        let mut steps = vec![];
+        let mut steps = Vec::with_capacity(choiced_steps.len());
         for step in choiced_steps.into_iter() {
             Self::push_applied(&mut steps, step)
         }
@@ -1584,7 +1584,7 @@ impl Cycle {
         limit: usize,
     ) -> Result<Events, String> {
         let range = span.whole_range();
-        let mut cycles = vec![];
+        let mut cycles = Vec::with_capacity(range.clone().count());
         for cycle in range {
             let mut events = Self::output(step, state, cycle, limit)?;
             events.transform_spans(&Span::new(Fraction::from(cycle), Fraction::from(cycle + 1)));
@@ -1840,7 +1840,7 @@ impl Cycle {
                 if sd.steps.is_empty() {
                     Events::empty()
                 } else {
-                    let mut events = vec![];
+                    let mut events = Vec::with_capacity(sd.steps.len());
                     for s in &sd.steps {
                         let e = Self::output(s, state, cycle, limit)?;
                         events.push(e)
@@ -1878,7 +1878,7 @@ impl Cycle {
                 if st.stack.is_empty() {
                     Events::empty()
                 } else {
-                    let mut channels = vec![];
+                    let mut channels = Vec::with_capacity(st.stack.len());
                     for s in &st.stack {
                         channels.push(Self::output(s, state, cycle, limit)?)
                     }
@@ -1935,6 +1935,7 @@ impl Cycle {
                                 };
                                 if let Some(steps) = steps_single.value.to_integer() {
                                     if let Some(pulses) = pulses_single.value.to_integer() {
+                                        events.reserve(pulses as usize);
                                         let out =
                                             Self::output(b.left.as_ref(), state, cycle, limit)?;
                                         for pulse in euclidean(


### PR DESCRIPTION
Improves cycle generation runtime performance by 20-25%. This is near micro-optimization, but at least fixes the small performance issues introduced in the last pr #54. 

The biggest speedup here is the change from `Fraction` to `num_rational`. ~ a 3rd of the CPU time in the cycle generate benchmarks are caused by fraction math according to my profiling. `Fraction` does a lot of things at runtime to deal with invalid/nan numbers. `num_rational` does not, and will, as Rust generally does with floating point numbers, panic instead. I think this is a good thing, as we don't test fractional result values for nan values anyway so they won't go unnoticed now. 

I may have missed a case where we do now need to check 0 divs, but those will be easy to fix once they happen and get reported...

@unlessgames decide you if that's worth the troubles or not.