### PR TITLE
Mono Trigger Mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "afseq"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Experimental, dynamic, imperative and functional music sequence generator for Rust and Lua"
 authors = ["Eduard Müller <mail@emuell.net>", "unless <unlessgames@gmail.com>"]

--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -180,18 +180,13 @@
 ### step_length : [`number`](../API/builtins/number.md)<a name="step_length"></a>
 > step length fraction within the cycle, where 1 is the total duration of a single cycle run.
 
-### trigger_note : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_note"></a>
-> Note value that triggered, started the rhythm, if any.
-
-### trigger_volume : [`number`](../API/builtins/number.md)[`?`](../API/builtins/nil.md)<a name="trigger_volume"></a>
-> Note volume that triggered, started the rhythm, if any.
-
-### trigger_offset : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_offset"></a>
-> Note slice offset value that triggered, started the rhythm, if any.
+### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
+> Notes that triggered the rhythm:
+> * Mono mode: All active trigger notes (last released note stops the rhythm)
+> * Poly mode: Single note that started the rhythm instance
 
 ### inputs : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="inputs"></a>
-> Current input parameter values, using parameter ids as keys
-> and the actual parameter value as value.
+>  Current input parameter values: parameter ids as keys, parameter values as values
 
 ### beats_per_min : [`number`](../API/builtins/number.md)<a name="beats_per_min"></a>
 > Project's tempo in beats per minutes.

--- a/docs/src/API/note.md
+++ b/docs/src/API/note.md
@@ -21,13 +21,25 @@
 > 
 > #### examples:
 >  ```lua
->  note(60) -- middle C
->  note("c4") -- middle C
->  note("c4 #2 v0.5 d0.3") -- middle C with additional properties
->  note({key="c4", volume=0.5}) -- middle C with volume 0.5
->  note("c4'maj v0.7") -- C4 major chord with volume 0.7
->  note("c4", "e4 v0.5", "off") -- custom chord with a c4, e4 and 'off' note
->  ```  
+>  note(48) --> middle C
+>  note("c4") --> middle C
+>  note("c4 #2 v0.5 d0.3") --> middle C with additional properties
+>  note({key="c4", volume=0.5}) --> middle C with volume 0.5
+>  note("c4'maj v0.7") --> C4 major chord with volume 0.7
+>  note("c4", "e4 v0.5", "off") --> custom chord with a c4, e4 and 'off' note
+>  ```
+### note_number(note : [`NoteValue`](#NoteValue))<a name="note_number"></a>
+`->`[`integer`](../API/builtins/integer.md)  
+
+> Convert a note string or note table to a raw MIDI note number in range 0-127
+> or -1 for nil or off note values.
+> ### Examples:
+> ```lua
+> note_value("c4") --> 48
+> note_value(note("c4")) --> 48
+> note_value("off") --> -1
+> note_value("xyz") --> error
+> ```  
 
 
 
@@ -105,7 +117,7 @@
 ---  
 ## Properties
 ### key : [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)<a name="key"></a>
-> Note Key
+> Note key & octave string (or MIDI note number as setter)
 
 ### instrument : [`number`](../API/builtins/number.md)[`?`](../API/builtins/nil.md)<a name="instrument"></a>
 > Instrument/Sample/Patch >= 0

--- a/docs/src/API/rhythm.md
+++ b/docs/src/API/rhythm.md
@@ -25,8 +25,8 @@
 >   unit = "bars",
 >   resolution = 4,
 >   offset = 1,
->   emit = { 
->     note("c4'm"), 
+>   emit = {
+>     note("c4'm"),
 >     note("g3'm7"):transpose({ 0, 12, 0, 0 })
 >   }
 > }
@@ -37,7 +37,7 @@
 > return rhythm {
 >   unit = "1/8",
 >   pattern = { 1, { 0, 1 }, 0, 0.3, 0.2, 1, { 0.5, 0.1, 1 }, 0.5 },
->   gate = function(init_context) 
+>   gate = function(init_context)
 >     local rand = math.randomstate(seed)
 >     return function(context)
 >       return context.pulse_value > rand()
@@ -88,22 +88,17 @@
 
 
 # EmitterContext<a name="EmitterContext"></a>  
-> Context passed to 'emit' functions.  
+> Context passed to functions in 'emit'.  
 
 ---  
 ## Properties
-### trigger_note : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_note"></a>
-> Note value that triggered, started the rhythm, if any.
-
-### trigger_volume : [`number`](../API/builtins/number.md)[`?`](../API/builtins/nil.md)<a name="trigger_volume"></a>
-> Note volume that triggered, started the rhythm, if any.
-
-### trigger_offset : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_offset"></a>
-> Note slice offset value that triggered, started the rhythm, if any.
+### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
+> Notes that triggered the rhythm:
+> * Mono mode: All active trigger notes (last released note stops the rhythm)
+> * Poly mode: Single note that started the rhythm instance
 
 ### inputs : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="inputs"></a>
-> Current input parameter values, using parameter ids as keys
-> and the actual parameter value as value.
+>  Current input parameter values: parameter ids as keys, parameter values as values
 
 ### beats_per_min : [`number`](../API/builtins/number.md)<a name="beats_per_min"></a>
 > Project's tempo in beats per minutes.
@@ -167,22 +162,17 @@
 
 
 # GateContext<a name="GateContext"></a>  
-> Context passed to `gate` functions.  
+> Context passed to functions in `gate`.  
 
 ---  
 ## Properties
-### trigger_note : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_note"></a>
-> Note value that triggered, started the rhythm, if any.
-
-### trigger_volume : [`number`](../API/builtins/number.md)[`?`](../API/builtins/nil.md)<a name="trigger_volume"></a>
-> Note volume that triggered, started the rhythm, if any.
-
-### trigger_offset : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_offset"></a>
-> Note slice offset value that triggered, started the rhythm, if any.
+### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
+> Notes that triggered the rhythm:
+> * Mono mode: All active trigger notes (last released note stops the rhythm)
+> * Poly mode: Single note that started the rhythm instance
 
 ### inputs : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="inputs"></a>
-> Current input parameter values, using parameter ids as keys
-> and the actual parameter value as value.
+>  Current input parameter values: parameter ids as keys, parameter values as values
 
 ### beats_per_min : [`number`](../API/builtins/number.md)<a name="beats_per_min"></a>
 > Project's tempo in beats per minutes.
@@ -221,22 +211,17 @@
 
 
 # PatternContext<a name="PatternContext"></a>  
-> Context passed to `pattern` and `gate` functions.  
+> Pattern passed to functions in `pattern` and `gate`.  
 
 ---  
 ## Properties
-### trigger_note : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_note"></a>
-> Note value that triggered, started the rhythm, if any.
-
-### trigger_volume : [`number`](../API/builtins/number.md)[`?`](../API/builtins/nil.md)<a name="trigger_volume"></a>
-> Note volume that triggered, started the rhythm, if any.
-
-### trigger_offset : [`integer`](../API/builtins/integer.md)[`?`](../API/builtins/nil.md)<a name="trigger_offset"></a>
-> Note slice offset value that triggered, started the rhythm, if any.
+### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
+> Notes that triggered the rhythm:
+> * Mono mode: All active trigger notes (last released note stops the rhythm)
+> * Poly mode: Single note that started the rhythm instance
 
 ### inputs : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="inputs"></a>
-> Current input parameter values, using parameter ids as keys
-> and the actual parameter value as value.
+>  Current input parameter values: parameter ids as keys, parameter values as values
 
 ### beats_per_min : [`number`](../API/builtins/number.md)<a name="beats_per_min"></a>
 > Project's tempo in beats per minutes.
@@ -265,18 +250,47 @@
 
 ---  
 ## Properties
+### mono : [`boolean`](../API/builtins/boolean.md)[`?`](../API/builtins/nil.md)<a name="mono"></a>
+> Set optional trigger mode. By default false, so rhythms are `polyphonic` by default.
+> 
+> * `mono` mode will start the rhythm with the first note that got triggered, and will
+> pass all subsequent notes to the existing rhythm instance until all notes get released.
+> * `poly` mode will start a new rhythm instance for every new note and will stop the
+> rhythm instance when the note is released.
+> 
+> Monophonic modes can be used to create arpeggio or chord mapping alike rhythms, which
+> need to consume multiple input notes.
+> 
+> ---#### examples:
+> ```lua
+> -- emit triggerd chords to a sequence of notes (an arpeggio)
+> return rhythm {
+>   mono = true,
+>   emit = function (init_context)
+>     -- index in arp as local state
+>     local note_index = 0
+>     return function (context)
+>       -- advance and wrap to next note in triggered notes
+>       local notes = context.triggers.notes
+>       note_index = math.imod(note_index + 1, #notes)
+>       return notes[note_index]
+>     end
+>   end
+> }
+> ```
+
 ### unit : `"ms"` | `"seconds"` | `"bars"` | `"beats"` | `"1/1"` | `"1/2"` | `"1/4"` | `"1/8"` | `"1/16"` | `"1/32"` | `"1/64"`<a name="unit"></a>
 > Base time unit of the emitter. Use `resolution` to apply an additional factor, in order to
 > create other less common rhythm bases.
 > #### examples:
 > ```lua
 > -- slightly off beat pulse
-> unit = "beats", 
+> unit = "beats",
 > resolution = 1.01
 > ```
 > ```lua
 > -- triplet
-> unit = "1/16", 
+> unit = "1/16",
 > resolution = 4/3
 > ```
 
@@ -330,7 +344,7 @@
 > ```
 
 ### pattern : [`boolean`](../API/builtins/boolean.md) | [`number`](../API/builtins/number.md) | `0` | `1` | [`Pulse`](#Pulse) | [`nil`](../API/builtins/nil.md)[] | (context : [`PatternContext`](../API/rhythm.md#PatternContext)) `->` [`boolean`](../API/builtins/boolean.md) | [`number`](../API/builtins/number.md) | `0` | `1` | [`Pulse`](#Pulse) | [`nil`](../API/builtins/nil.md) | (context : [`PatternContext`](../API/rhythm.md#PatternContext)) `->` (context : [`PatternContext`](../API/rhythm.md#PatternContext)) `->` [`boolean`](../API/builtins/boolean.md) | [`number`](../API/builtins/number.md) | `0` | `1` | [`Pulse`](#Pulse) | [`nil`](../API/builtins/nil.md)<a name="pattern"></a>
-> Specify the rhythmical pattern of the rhythm. With the default `gate` implementation, 
+> Specify the rhythmical pattern of the rhythm. With the default `gate` implementation,
 > each pulse with a value of `1` or `true` will cause an event from the `emitter` property
 > to be triggered in the emitters time unit. `0`, `false` or `nil` values do not trigger.
 > 
@@ -398,10 +412,10 @@
 ### gate : (context : [`GateContext`](../API/rhythm.md#GateContext)) `->` [`boolean`](../API/builtins/boolean.md) | (context : [`GateContext`](../API/rhythm.md#GateContext)) `->` (context : [`GateContext`](../API/rhythm.md#GateContext)) `->` [`boolean`](../API/builtins/boolean.md)<a name="gate"></a>
 > Optional pulse train filter function or generator function which filters events between
 > the pattern and emitter. By default a threshold gate, which passes all pulse values
-> greater than zero. 
+> greater than zero.
 > 
-> Custom function should returns true when a pattern pulse value should be passed, 
-> and false when the emitter should be skipped.  
+> Custom function should returns true when a pattern pulse value should be passed,
+> and false when the emitter should be skipped.
 > 
 > #### examples:
 > ```lua

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Advanced Topics](extras/README.md)
   - [Generators](extras/generators.md)
   - [Randomization](extras/randomization.md)
+  - [Triggering Rhythms](extras/triggering_rhythms.md)
 - [Examples](examples/README.md)
 - [API Reference](API/README.md)
   <!-- API TOC START -->

--- a/docs/src/extras/mono_triggering.md
+++ b/docs/src/extras/mono_triggering.md
@@ -1,0 +1,43 @@
+# Rhythm Trigger Modes
+
+When triggering rhythms with notes, e.g. from a MIDI keyboard or in the sequencer of a DAW, a new rhythm instance is started by default for each incoming triggered note.
+
+The rhythm's [`mono`](../API/rhythm.md#mono--boolean) property modifies this behavior.
+
+Monophonic modes can be used to create arpeggio or chord mapping alike rhythms, which consume multiple input notes.
+
+### Polyphonic Mode (`mono = false`) - Default
+- Creates a new rhythm instance for each new note.
+- Stops each instance when its corresponding note is released.
+
+### Monophonic Mode (`mono = true`)
+- Starts the rhythm with the first triggered note.
+- Passes all subsequent notes *to the same rhythm* instance.
+- Continues running until all notes are released.
+
+## Examples
+
+An arpeggio that cycles through all currently held notes.
+
+```lua
+return rhythm {
+    mono = true, -- Enable monophonic rhythm triggering
+    emit = function(init_context)
+        -- Local state for tracking arpeggio position
+        local note_index = 0
+        return function(context)
+            local notes = context.trigger.notes
+            if #notes == 0 then 
+              -- Skip if no notes held
+              return
+            end 
+            -- Advance and wrap arpeggio position
+            note_index = math.imod(note_index + 1, #notes)
+            -- Return current note from held chord
+            return notes[note_index]
+        end
+    end
+}
+```
+
+See [generators](./generators.md) for details of how afseq handles global and local states in general.

--- a/docs/src/extras/triggering_rhythms.md
+++ b/docs/src/extras/triggering_rhythms.md
@@ -1,0 +1,43 @@
+# Rhythm Trigger Modes
+
+When triggering rhythms with notes, e.g. from a MIDI keyboard or in the sequencer of a DAW, a new rhythm instance is started by default for each incoming triggered note.
+
+The rhythm's [`mono`](../API/rhythm.md#mono--boolean) property modifies this behavior.
+
+Monophonic modes can be used to create arpeggio or chord mapping alike rhythms, which consume multiple input notes.
+
+### Polyphonic Mode (`mono = false`) - Default
+- Creates a new rhythm instance for each new note.
+- Stops each instance when its corresponding note is released.
+
+### Monophonic Mode (`mono = true`)
+- Starts the rhythm with the first triggered note.
+- Passes all subsequent notes *to the same rhythm* instance.
+- Continues running until all notes are released.
+
+## Examples
+
+An arpeggio that cycles through all currently held notes.
+
+```lua
+return rhythm {
+    mono = true, -- Enable monophonic triggering
+    emit = function(init_context)
+        -- Local state for tracking arpeggio position
+        local note_index = 0
+        return function(context)
+            local notes = context.trigger.notes
+            if #notes == 0 then 
+              -- Skip if no notes held
+              return
+            end 
+            -- Advance and wrap arpeggio position
+            note_index = math.imod(note_index + 1, #notes)
+            -- Return current note from held chord
+            return notes[note_index]
+        end
+    end
+}
+```
+
+See [generators](./generators.md) for details of how afseq handles global and local states in general.

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -16,7 +16,7 @@ use self::{
     rhythm::rhythm_from_userdata,
     sequence::SequenceUserData,
     unwrap::{
-        bad_argument_error, optional_string_from_value, string_from_value,
+        bad_argument_error, note_event_from_value, optional_string_from_value, string_from_value,
         validate_table_properties,
     },
 };
@@ -235,6 +235,20 @@ fn register_global_bindings(
         "note",
         lua.create_function(|_lua, args: LuaMultiValue| -> LuaResult<NoteUserData> {
             NoteUserData::from(args)
+        })?,
+    )?;
+
+    // function note_number(note)
+    globals.raw_set(
+        "note_number",
+        lua.create_function(|_lua, value: LuaValue| -> LuaResult<LuaValue> {
+            let note_event = note_event_from_value(&value, None)?;
+            match note_event {
+                Some(note_event) if note_event.note.is_note_on() => {
+                    Ok(LuaValue::Integer(u8::from(note_event.note) as LuaInteger))
+                }
+                _ => Ok(LuaValue::Integer(-1 as LuaInteger)),
+            }
         })?,
     )?;
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -286,14 +286,15 @@ fn register_global_bindings(
             let time_base = *time_base;
             move |lua, table: LuaTable| -> LuaResult<LuaValue> {
                 // error on unknown option keys
-                const RHYTHM_PROPERTIES: [&str; 8] = [
+                const RHYTHM_PROPERTIES: [&str; 9] = [
+                    "mono",
                     "unit",
                     "resolution",
                     "offset",
+                    "repeats",
                     "inputs",
                     "pattern",
                     "gate",
-                    "repeats",
                     "emit",
                 ];
                 validate_table_properties(&table, &RHYTHM_PROPERTIES)?;
@@ -884,7 +885,7 @@ mod test {
         new_rhythm_from_string(
             time_base,
             None,
-            r#"return rhythm { unit = "1/4", emit = "c4" }"#,
+            r#"return rhythm { mono = false, unit = "1/4", emit = "c4" }"#,
             "[test beat rhythm]",
         )?;
 
@@ -892,7 +893,7 @@ mod test {
         new_rhythm_from_string(
             time_base,
             None,
-            r#"return rhythm { unit = "ms", emit = "c4" }"#,
+            r#"return rhythm { mono = true, unit = "ms", emit = "c4" }"#,
             "[test second time rhythm]",
         )?;
 

--- a/src/bindings/note.rs
+++ b/src/bindings/note.rs
@@ -246,6 +246,13 @@ mod test {
             .clone())
     }
 
+    fn evaluate_number(lua: &Lua, expression: &str) -> LuaResult<LuaInteger> {
+        lua.load(expression)
+            .eval::<LuaValue>()?
+            .as_integer()
+            .ok_or(LuaError::RuntimeError("No integer value".to_string()))
+    }
+
     #[test]
     fn note() -> LuaResult<()> {
         let (lua, _) = new_test_engine()?;
@@ -535,6 +542,26 @@ mod test {
                 new_note(("e4", None, 1.0, 0.0)),
             ]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn note_numbers() -> LuaResult<()> {
+        let (lua, _) = new_test_engine()?;
+
+        // Note number
+        assert!(evaluate_number(
+            &lua,
+            r#"note_number("x1")#).is_err());
+        assert!(evaluate_number(&lua, r#"note_number({})"#
+        )
+        .is_err());
+        assert!(evaluate_number(&lua, r#"note_number(-1)"#).is_err());
+        assert_eq!(evaluate_number(&lua, r#"note_number("c4")"#)?, 48);
+        assert_eq!(evaluate_number(&lua, r#"note_number("off")"#)?, -1);
+        assert_eq!(evaluate_number(&lua, r#"note_number("---")"#)?, -1);
+        assert_eq!(evaluate_number(&lua, r#"note_number(nil)"#)?, -1);
 
         Ok(())
     }

--- a/src/bindings/rhythm.rs
+++ b/src/bindings/rhythm.rs
@@ -190,11 +190,12 @@ mod test {
                         assert(context.beats_per_min == 120)
                         assert(context.beats_per_bar == 4)
                         assert(context.samples_per_sec == 44100)
-                        assert(#context.triggers == 1)
-                        assert(context.triggers[1].key == "A4")
-                        assert(context.triggers[1].volume == 0.5)
-                        assert(context.triggers[1].panning == 0.0)
-                        assert(context.triggers[1].delay == 0.25)
+                        local trigger_notes = context.trigger.notes
+                        assert(#trigger_notes == 1)
+                        assert(trigger_notes[1].key == "A4")
+                        assert(trigger_notes[1].volume == 0.5)
+                        assert(trigger_notes[1].panning == 0.0)
+                        assert(trigger_notes[1].delay == 0.25)
                         assert(context.pulse_step == pulse_step)
                         assert(context.pulse_time_step == pulse_time_step)
                       end
@@ -214,7 +215,8 @@ mod test {
                         assert(context.beats_per_min == 120)
                         assert(context.beats_per_bar == 4)
                         assert(context.samples_per_sec == 44100)
-                        assert(#context.triggers == 1 and context.triggers[1].key == "A4")
+                        assert(#context.trigger.notes == 1 and 
+                          context.trigger.notes[1].key == "A4")
                         assert(context.pulse_step == pulse_step)
                         assert(context.pulse_time_step == pulse_time_step)
                       end
@@ -236,7 +238,8 @@ mod test {
                         assert(context.beats_per_min == 120)
                         assert(context.beats_per_bar == 4)
                         assert(context.samples_per_sec == 44100)
-                        assert(#context.triggers == 1 and context.triggers[1].key == "A4")
+                        assert(#context.trigger.notes == 1 and 
+                          context.trigger.notes[1].key == "A4")
                         assert(context.pulse_step == pulse_step)
                         assert(context.pulse_time_step == pulse_time_step)
                         assert(context.step == step)

--- a/src/bindings/rhythm/beat_time.rs
+++ b/src/bindings/rhythm/beat_time.rs
@@ -3,7 +3,7 @@ use mlua::prelude::*;
 use super::super::{
     unwrap::{
         bad_argument_error, event_iter_from_value, gate_from_value, inputs_from_value,
-        pattern_from_value, pattern_repeat_count_from_value,
+        pattern_from_value, pattern_repeat_count_from_value, trigger_mode_from_mono_value,
     },
     LuaTimeoutHook,
 };
@@ -50,7 +50,7 @@ impl BeatTimeRhythm {
                 "1/16" => step = BeatTimeStep::Sixteenth(resolution),
                 "1/32" => step = BeatTimeStep::ThirtySecond(resolution),
                 "1/64" => step = BeatTimeStep::SixtyFourth(resolution),
-                _ => return Err(bad_argument_error("emit", "unit", 1, 
+                _ => return Err(bad_argument_error("rhythm", "unit", 1, 
                 "expected one of 'ms|seconds' or 'bars|beats' or '1/1|1/2|1/4|1/8|1/16|1/32|1/64"))
             }
         }
@@ -77,6 +77,12 @@ impl BeatTimeRhythm {
             let value = table.get::<LuaTable>("inputs")?;
             let inputs = inputs_from_value(lua, &value)?;
             rhythm = rhythm.with_input_parameters(inputs);
+        }
+        // mono
+        if table.contains_key("mono")? {
+            let value = table.get::<LuaValue>("mono")?;
+            let trigger_mode = trigger_mode_from_mono_value(&value)?;
+            rhythm = rhythm.with_trigger_mode(trigger_mode);
         }
         // pattern
         if table.contains_key("pattern")? {

--- a/src/bindings/rhythm/second_time.rs
+++ b/src/bindings/rhythm/second_time.rs
@@ -3,7 +3,7 @@ use mlua::prelude::*;
 use super::super::{
     unwrap::{
         bad_argument_error, event_iter_from_value, gate_from_value, inputs_from_value,
-        pattern_from_value, pattern_repeat_count_from_value,
+        pattern_from_value, pattern_repeat_count_from_value, trigger_mode_from_mono_value,
     },
     LuaTimeoutHook,
 };
@@ -43,7 +43,7 @@ impl SecondTimeRhythm {
             match unit.as_str() {
                 "seconds" => (),
                 "ms" => resolution /= 1000.0,
-                _ => return Err(bad_argument_error("emit", "unit", 1, 
+                _ => return Err(bad_argument_error("rhythm", "unit", 1, 
                 "expected one of 'ms|seconds' or 'bars|beats' or '1/1|1/2|1/4|1/8|1/16|1/32|1/64"))
             }
         }
@@ -62,6 +62,12 @@ impl SecondTimeRhythm {
                     "offset must be a number >= 0",
                 ));
             }
+        }
+        // mono
+        if table.contains_key("mono")? {
+            let value = table.get::<LuaValue>("mono")?;
+            let trigger_mode = trigger_mode_from_mono_value(&value)?;
+            rhythm = rhythm.with_trigger_mode(trigger_mode);
         }
         // inputs
         if table.contains_key("inputs")? {

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -119,8 +119,9 @@ impl IntoLua for ParameterChangeEvent {
 impl IntoLua for Event {
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         match self {
-            Event::NoteEvents(note_events) => note_events.into_lua(lua),
+            Event::NoteEvents(note_events) => NoteUserData { notes: note_events }.into_lua(lua),
             Event::ParameterChangeEvent(parameter_change_event) => {
+                // TODO: ParameterChangeUserData
                 parameter_change_event.into_lua(lua)
             }
         }
@@ -740,6 +741,25 @@ pub(crate) fn chord_events_from_intervals(
             to: "note".to_string(),
             message: Some("invalid note in chord: note value is undefined".to_string()),
         })
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+pub fn trigger_mode_from_mono_value(value: &LuaValue) -> LuaResult<RhythmTriggerMode> {
+    match value.as_boolean() {
+        Some(value) => {
+            if value {
+                Ok(RhythmTriggerMode::Mono)
+            } else {
+                Ok(RhythmTriggerMode::Poly)
+            }
+        }
+        None => Err(LuaError::FromLuaConversionError {
+            from: value.type_name(),
+            to: "trigger_mode".to_string(),
+            message: Some("expected a boolean value for `mono` property".to_string()),
+        }),
     }
 }
 

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -103,6 +103,32 @@ impl IntoLua for NoteEvent {
 
 // ---------------------------------------------------------------------------------------------
 
+impl IntoLua for ParameterChangeEvent {
+    fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
+        let table = lua.create_table()?;
+        if let Some(id) = self.parameter {
+            table.set("parameter", usize::from(id).into_lua(lua)?)?;
+        }
+        table.set("value", self.value as f64)?;
+        Ok(LuaValue::Table(table))
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+
+impl IntoLua for Event {
+    fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
+        match self {
+            Event::NoteEvents(note_events) => note_events.into_lua(lua),
+            Event::ParameterChangeEvent(parameter_change_event) => {
+                parameter_change_event.into_lua(lua)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+
 // Check if a lua value is a string, without using implicit conversions.
 pub(crate) fn string_from_value(
     value: &LuaValue,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,6 @@
 //! Events and event iterators which get emitted by a `Rhythm`.
 
 use std::{
-    borrow::Cow,
     fmt::Debug,
     fmt::Display,
     sync::atomic::{AtomicUsize, Ordering},
@@ -403,8 +402,8 @@ pub trait EventIter: Debug {
     /// Update the iterator's internal beat or second time base with the new time base.
     fn set_time_base(&mut self, time_base: &BeatTimeBase);
 
-    /// Set optional, application specific external context data for the event iter.
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]);
+    /// Set optional event which triggered, started the iter, if any.
+    fn set_trigger_event(&mut self, event: &Event);
 
     /// Set or update optional, input parameter map for callbacks.
     fn set_input_parameters(&mut self, parameters: InputParameterSet);

--- a/src/event/cycle.rs
+++ b/src/event/cycle.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, ops::RangeBounds};
+use std::{collections::HashMap, ops::RangeBounds};
 
 type Fraction = num_rational::Rational32;
 
@@ -345,7 +345,7 @@ impl EventIter for CycleEventIter {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/event/empty.rs
+++ b/src/event/empty.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use crate::{BeatTimeBase, EventIter, EventIterItem, InputParameterSet, PulseIterItem};
+use crate::{BeatTimeBase, Event, EventIter, EventIterItem, InputParameterSet, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -13,7 +11,7 @@ impl EventIter for EmptyEventIter {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/event/fixed.rs
+++ b/src/event/fixed.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::{
     event::new_note, BeatTimeBase, Event, EventIter, EventIterItem, InputParameterSet, Note,
     NoteEvent, ParameterChangeEvent, PulseIterItem,
@@ -94,7 +92,7 @@ impl EventIter for FixedEventIter {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/event/mutated.rs
+++ b/src/event/mutated.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Debug};
+use std::fmt::Debug;
 
 use crate::{
     event::fixed::FixedEventIter, BeatTimeBase, Event, EventIter, EventIterItem, InputParameterSet,
@@ -68,7 +68,7 @@ impl EventIter for MutatedEventIter {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/event/scripted.rs
+++ b/src/event/scripted.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use mlua::prelude::LuaResult;
 
 use crate::{
@@ -118,11 +116,11 @@ impl EventIter for ScriptedEventIter {
         }
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, event: &Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_external_data(data) {
+        if let Err(err) = self.callback.set_context_triggers(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/event/scripted.rs
+++ b/src/event/scripted.rs
@@ -120,7 +120,7 @@ impl EventIter for ScriptedEventIter {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_triggers(event) {
+        if let Err(err) = self.callback.set_context_trigger_event(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -269,7 +269,7 @@ impl EventIter for ScriptedCycleEventIter {
             timeout_hook.reset();
         }
         if let Some(callback) = &mut self.mapping_callback {
-            if let Err(err) = callback.set_context_triggers(event) {
+            if let Err(err) = callback.set_context_trigger_event(event) {
                 callback.handle_error(&err);
             }
         }

--- a/src/event/scripted_cycle.rs
+++ b/src/event/scripted_cycle.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap};
+use std::collections::HashMap;
 
 use num_traits::ToPrimitive;
 
@@ -10,8 +10,8 @@ use crate::{
         LuaTimeoutHook,
     },
     event::cycle::{apply_cycle_note_properties, CycleNoteEvents},
-    BeatTimeBase, Cycle, CycleEvent, CycleValue, EventIter, EventIterItem, InputParameterSet,
-    NoteEvent, PulseIterItem,
+    BeatTimeBase, Cycle, CycleEvent, CycleValue, Event, EventIter, EventIterItem,
+    InputParameterSet, NoteEvent, PulseIterItem,
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -264,12 +264,12 @@ impl EventIter for ScriptedCycleEventIter {
         }
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, event: &Event) {
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
         if let Some(callback) = &mut self.mapping_callback {
-            if let Err(err) = callback.set_context_external_data(data) {
+            if let Err(err) = callback.set_context_triggers(event) {
                 callback.handle_error(&err);
             }
         }

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -1,8 +1,8 @@
 //! Defines if an `Event` should be triggered or not for a given `Pulse`.
 
-use std::{borrow::Cow, fmt::Debug};
+use std::fmt::Debug;
 
-use crate::{BeatTimeBase, InputParameterSet, PulseIterItem};
+use crate::{BeatTimeBase, Event, InputParameterSet, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -19,8 +19,8 @@ pub trait Gate: Debug {
     /// Set or update the gate's internal beat or second time base with the new time base.
     fn set_time_base(&mut self, time_base: &BeatTimeBase);
 
-    /// Set or update optional, application specific external context data for the gate.
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]);
+    /// Set optional event which triggered, started the iter, if any.
+    fn set_trigger_event(&mut self, event: &Event);
 
     /// Set or update optional, input parameter map for callbacks.
     fn set_input_parameters(&mut self, parameters: InputParameterSet);

--- a/src/gate/probability.rs
+++ b/src/gate/probability.rs
@@ -1,9 +1,7 @@
-use std::borrow::Cow;
-
 use rand::{rng, Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
-use crate::{BeatTimeBase, Gate, InputParameterSet, PulseIterItem};
+use crate::{BeatTimeBase, Event, Gate, InputParameterSet, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -28,7 +26,7 @@ impl Gate for ProbabilityGate {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 
@@ -37,7 +35,8 @@ impl Gate for ProbabilityGate {
     }
 
     fn run(&mut self, pulse: &PulseIterItem) -> bool {
-        pulse.value >= 1.0 || (pulse.value > 0.0 && pulse.value > self.rand_gen.random_range(0.0..1.0))
+        pulse.value >= 1.0
+            || (pulse.value > 0.0 && pulse.value > self.rand_gen.random_range(0.0..1.0))
     }
 
     fn duplicate(&self) -> Box<dyn Gate> {

--- a/src/gate/scripted.rs
+++ b/src/gate/scripted.rs
@@ -79,7 +79,7 @@ impl Gate for ScriptedGate {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_triggers(event) {
+        if let Err(err) = self.callback.set_context_trigger_event(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/gate/scripted.rs
+++ b/src/gate/scripted.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
-
 use mlua::prelude::LuaResult;
 
 use crate::{
     bindings::{gate_trigger_from_value, LuaCallback, LuaTimeoutHook},
-    BeatTimeBase, Gate, InputParameterSet, PulseIterItem,
+    BeatTimeBase, Event, Gate, InputParameterSet, PulseIterItem,
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -77,11 +75,11 @@ impl Gate for ScriptedGate {
         }
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, event: &Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_external_data(data) {
+        if let Err(err) = self.callback.set_context_triggers(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/gate/threshold.rs
+++ b/src/gate/threshold.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use crate::{BeatTimeBase, Gate, InputParameterSet, PulseIterItem};
+use crate::{BeatTimeBase, Event, Gate, InputParameterSet, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -31,7 +29,7 @@ impl Gate for ThresholdGate {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub mod gate;
 pub use gate::Gate;
 
 pub mod rhythm;
-pub use rhythm::{Rhythm, RhythmIter, RhythmIterItem};
+pub use rhythm::{Rhythm, RhythmIter, RhythmIterItem, RhythmTriggerMode};
 
 pub mod phrase;
 pub use phrase::{Phrase, RhythmSlot};

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,8 +1,8 @@
 //! Rhythmical pattern as sequence of pulses in a `Rhythm`.
 
-use std::{borrow::Cow, fmt::Debug};
+use std::fmt::Debug;
 
-use crate::{BeatTimeBase, InputParameterSet, PulseIterItem};
+use crate::{BeatTimeBase, Event, InputParameterSet, PulseIterItem};
 
 pub mod empty;
 pub mod euclidean;
@@ -30,8 +30,8 @@ pub trait Pattern: Debug {
     /// Set or update the pattern's internal beat or second time base with the new time base.
     fn set_time_base(&mut self, time_base: &BeatTimeBase);
 
-    /// Set optional, application specific external context data for the pattern.
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]);
+    /// Set optional event which triggered, started the iter, if any, before running.
+    fn set_trigger_event(&mut self, event: &Event);
 
     /// Set or update optional, input parameter map for callbacks.
     fn set_input_parameters(&mut self, parameters: InputParameterSet);

--- a/src/pattern/empty.rs
+++ b/src/pattern/empty.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use crate::{BeatTimeBase, InputParameterSet, Pattern, PulseIterItem};
+use crate::{BeatTimeBase, Event, InputParameterSet, Pattern, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -27,7 +25,7 @@ impl Pattern for EmptyPattern {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/pattern/fixed.rs
+++ b/src/pattern/fixed.rs
@@ -1,7 +1,5 @@
-use std::borrow::Cow;
-
 use super::euclidean::euclidean;
-use crate::{BeatTimeBase, InputParameterSet, Pattern, Pulse, PulseIter, PulseIterItem};
+use crate::{BeatTimeBase, Event, InputParameterSet, Pattern, Pulse, PulseIter, PulseIterItem};
 
 // -------------------------------------------------------------------------------------------------
 
@@ -97,7 +95,7 @@ impl Pattern for FixedPattern {
         // nothing to do
     }
 
-    fn set_external_context(&mut self, _data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, _event: &Event) {
         // nothing to do
     }
 

--- a/src/pattern/scripted.rs
+++ b/src/pattern/scripted.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use mlua::prelude::LuaResult;
 
 use crate::{
@@ -147,11 +145,11 @@ impl Pattern for ScriptedPattern {
         }
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, event: &crate::Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_external_data(data) {
+        if let Err(err) = self.callback.set_context_triggers(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/pattern/scripted.rs
+++ b/src/pattern/scripted.rs
@@ -149,7 +149,7 @@ impl Pattern for ScriptedPattern {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_triggers(event) {
+        if let Err(err) = self.callback.set_context_trigger_event(event) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/phrase.rs
+++ b/src/phrase.rs
@@ -1,9 +1,9 @@
 //! Stack multiple `Rhythm`S into a single one.
 
-use std::{borrow::Cow, cell::RefCell, cmp::Ordering, fmt::Debug, rc::Rc};
+use std::{cell::RefCell, cmp::Ordering, fmt::Debug, rc::Rc};
 
 use crate::{
-    BeatTimeBase, BeatTimeStep, InputParameter, InputParameterSet, InstrumentId, Rhythm,
+    BeatTimeBase, BeatTimeStep, Event, InputParameter, InputParameterSet, InstrumentId, Rhythm,
     RhythmIter, RhythmIterItem, SampleTime, SampleTimeDisplay,
 };
 
@@ -119,7 +119,7 @@ impl Phrase {
         &self.rhythm_slots
     }
 
-    /// Run rhythms to produce a single next event, calling the given `consumer` 
+    /// Run rhythms to produce a single next event, calling the given `consumer`
     /// visitor function when an event got produced.
     pub fn consume_event<F>(&mut self, consumer: &mut F)
     where
@@ -316,10 +316,10 @@ impl Rhythm for Phrase {
         }
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
+    fn set_trigger_event(&mut self, event: &Event) {
         for rhythm_slot in &mut self.rhythm_slots {
             if let RhythmSlot::Rhythm(rhythm) = rhythm_slot {
-                rhythm.borrow_mut().set_external_context(data);
+                rhythm.borrow_mut().set_trigger_event(event);
             }
         }
     }

--- a/src/phrase.rs
+++ b/src/phrase.rs
@@ -4,7 +4,7 @@ use std::{cell::RefCell, cmp::Ordering, fmt::Debug, rc::Rc};
 
 use crate::{
     BeatTimeBase, BeatTimeStep, Event, InputParameter, InputParameterSet, InstrumentId, Rhythm,
-    RhythmIter, RhythmIterItem, SampleTime, SampleTimeDisplay,
+    RhythmIter, RhythmIterItem, RhythmTriggerMode, SampleTime, SampleTimeDisplay,
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -312,6 +312,23 @@ impl Rhythm for Phrase {
         for rhythm_slot in &mut self.rhythm_slots {
             if let RhythmSlot::Rhythm(rhythm) = rhythm_slot {
                 rhythm.borrow_mut().set_instrument(instrument);
+            }
+        }
+    }
+
+    fn trigger_mode(&self) -> RhythmTriggerMode {
+        for rhythm_slot in &self.rhythm_slots {
+            if let RhythmSlot::Rhythm(rhythm) = rhythm_slot {
+                return rhythm.borrow().trigger_mode();
+            }
+        }
+        RhythmTriggerMode::Poly
+    }
+
+    fn set_trigger_mode(&mut self, mode: RhythmTriggerMode) {
+        for rhythm_slot in &mut self.rhythm_slots {
+            if let RhythmSlot::Rhythm(rhythm) = rhythm_slot {
+                rhythm.borrow_mut().set_trigger_mode(mode);
             }
         }
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -49,6 +49,7 @@ pub use super::{
     RhythmIter,
     RhythmIterItem,
     RhythmSlot,
+    RhythmTriggerMode,
     SampleTime,
     Scale,
     SecondTimeBase,

--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -1,7 +1,7 @@
 //! Periodically emit `Events` via an `EventIter` with a given time base on a
 //! rhythmical pattern defined via a `Pattern`.
 
-use std::{borrow::Cow, cell::RefCell, fmt::Debug, rc::Rc};
+use std::{cell::RefCell, fmt::Debug, rc::Rc};
 
 use crate::{BeatTimeBase, Event, InputParameter, InstrumentId, SampleTime, SampleTimeDisplay};
 
@@ -114,6 +114,9 @@ pub trait Rhythm: RhythmIter {
 
     /// Set optional, application specific external context data for the pattern and emitter.
     fn set_external_context(&mut self, data: &[(Cow<str>, f64)]);
+
+    /// Set event which triggered, started the rhythm, if any.
+    fn set_trigger_event(&mut self, trigger: &Event);
 
     /// Create a new cloned instance of this rhythm. This actually is a clone(), wrapped into
     /// a `Box<dyn Rhythm>`, but called 'duplicate' to avoid conflicts with possible Clone impls.

--- a/src/rhythm.rs
+++ b/src/rhythm.rs
@@ -36,7 +36,7 @@ impl RhythmIterItem {
 
 // -------------------------------------------------------------------------------------------------
 
-/// A `RhythmIter` is an iterator which emits sample time tagged optional [`Event`](crate::Event)
+/// A `RhythmIter` is an iterator which emits sample time tagged optional [`Event`]
 /// items.
 ///
 /// It triggers events periodically, producing events at specific sample times with specific
@@ -87,6 +87,19 @@ impl Iterator for dyn RhythmIter {
 
 // -------------------------------------------------------------------------------------------------
 
+/// How rhythms should be triggered.
+#[derive(Default, Debug, Clone, Copy)]
+pub enum RhythmTriggerMode {
+    /// In poly mode, every new note event should start a new rhythm instance, which is the default.
+    #[default]
+    Poly,
+    /// In mono mode, only one rhythm instance should be triggered and should be fed with subsequent
+    /// triggered notes.
+    Mono,
+}
+
+// -------------------------------------------------------------------------------------------------
+
 /// A `Rhythm` is a resettable, dyn clonable `RhythmIter` with optional instrument and
 /// time base setters.
 ///
@@ -112,10 +125,14 @@ pub trait Rhythm: RhythmIter {
     /// instrument value set.
     fn set_instrument(&mut self, instrument: Option<InstrumentId>);
 
-    /// Set optional, application specific external context data for the pattern and emitter.
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]);
+    /// Rhythms external trigger mode. See `RhythmTriggerMode` for details.
+    fn trigger_mode(&self) -> RhythmTriggerMode;
+    /// Set rhythms external trigger mode. See `RhythmTriggerMode` for details.
+    fn set_trigger_mode(&mut self, mode: RhythmTriggerMode);
 
     /// Set event which triggered, started the rhythm, if any.
+    /// For rhythms with mono trigger mode newly triggered or released notes should be passed
+    /// as new event to the running rhythms.
     fn set_trigger_event(&mut self, trigger: &Event);
 
     /// Create a new cloned instance of this rhythm. This actually is a clone(), wrapped into

--- a/src/rhythm/generic.rs
+++ b/src/rhythm/generic.rs
@@ -14,7 +14,7 @@ use crate::{
     pattern::{fixed::FixedPattern, Pattern},
     time::{BeatTimeBase, SampleTimeDisplay},
     Gate, InputParameter, InputParameterSet, PulseIterItem, Rhythm, RhythmIter, RhythmIterItem,
-    SampleTime,
+    RhythmTriggerMode, SampleTime,
 };
 
 // -------------------------------------------------------------------------------------------------
@@ -43,6 +43,7 @@ pub struct GenericRhythm<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeS
     offset: Offset,
     instrument: Option<InstrumentId>,
     input_parameters: InputParameterSet,
+    trigger_mode: RhythmTriggerMode,
     pattern: Box<dyn Pattern>,
     pattern_repeat_count: Option<usize>,
     pattern_playback_finished: bool,
@@ -62,6 +63,7 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> GenericRhythm<S
         let offset = Offset::default_offset();
         let instrument = None;
         let input_parameters = InputParameterSet::new();
+        let trigger_mode = RhythmTriggerMode::Poly;
         let pattern = Box::<FixedPattern>::default();
         let pattern_repeat_count = None;
         let pattern_playback_finished = false;
@@ -78,6 +80,7 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> GenericRhythm<S
             offset,
             instrument,
             input_parameters,
+            trigger_mode,
             pattern,
             pattern_repeat_count,
             pattern_playback_finished,
@@ -144,6 +147,15 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> GenericRhythm<S
         new.gate.set_input_parameters(parameters.clone());
         new.event_iter.set_input_parameters(parameters);
         new
+    }
+
+    /// Return a new rhythm instance with the given trigger mode
+    #[must_use]
+    pub fn with_trigger_mode(self, trigger_mode: RhythmTriggerMode) -> Self {
+        Self {
+            trigger_mode,
+            ..self
+        }
     }
 
     /// Return a new rhythm instance which trigger events with the given [`Pattern`].  
@@ -484,6 +496,14 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> Rhythm
 
     fn set_instrument(&mut self, instrument: Option<InstrumentId>) {
         self.instrument = instrument;
+    }
+
+    fn trigger_mode(&self) -> RhythmTriggerMode {
+        self.trigger_mode
+    }
+
+    fn set_trigger_mode(&mut self, mode: RhythmTriggerMode) {
+        self.trigger_mode = mode;
     }
 
     fn set_trigger_event(&mut self, event: &Event) {

--- a/src/rhythm/generic.rs
+++ b/src/rhythm/generic.rs
@@ -1,12 +1,6 @@
 //! Generic `Rhythm` implementation with custom time step and offset types.
 
-use std::{
-    borrow::{Borrow, Cow},
-    cell::RefCell,
-    collections::VecDeque,
-    fmt::Debug,
-    rc::Rc,
-};
+use std::{borrow::Borrow, cell::RefCell, collections::VecDeque, fmt::Debug, rc::Rc};
 
 type Fraction = num_rational::Rational32;
 use num_traits::ToPrimitive;
@@ -492,10 +486,10 @@ impl<Step: GenericRhythmTimeStep, Offset: GenericRhythmTimeStep> Rhythm
         self.instrument = instrument;
     }
 
-    fn set_external_context(&mut self, data: &[(Cow<str>, f64)]) {
-        self.pattern.set_external_context(data);
-        self.gate.set_external_context(data);
-        self.event_iter.set_external_context(data);
+    fn set_trigger_event(&mut self, event: &Event) {
+        self.pattern.set_trigger_event(event);
+        self.gate.set_trigger_event(event);
+        self.event_iter.set_trigger_event(event);
     }
 
     fn duplicate(&self) -> Rc<RefCell<dyn Rhythm>> {

--- a/types/nerdo/library/note.lua
+++ b/types/nerdo/library/note.lua
@@ -7,7 +7,7 @@ error("Do not try to execute this file. It's just a type definition file.")
 ----------------------------------------------------------------------------------------------------
 
 ---@class NoteTable
----@field key string|number Note Key
+---@field key string|number Note key & octave string (or MIDI note number as setter)
 ---@field instrument number? Instrument/Sample/Patch >= 0
 ---@field volume number? Volume in range [0.0 - 1.0]
 ---@field panning number? Panning factor in range [-1.0 - 1.0] where 0 is center
@@ -98,12 +98,12 @@ function Note:delay(delay) end
 ---
 ---### examples:
 --- ```lua
---- note(60) -- middle C
---- note("c4") -- middle C
---- note("c4 #2 v0.5 d0.3") -- middle C with additional properties
---- note({key="c4", volume=0.5}) -- middle C with volume 0.5
---- note("c4'maj v0.7") -- C4 major chord with volume 0.7
---- note("c4", "e4 v0.5", "off") -- custom chord with a c4, e4 and 'off' note
+--- note(48) --> middle C
+--- note("c4") --> middle C
+--- note("c4 #2 v0.5 d0.3") --> middle C with additional properties
+--- note({key="c4", volume=0.5}) --> middle C with volume 0.5
+--- note("c4'maj v0.7") --> C4 major chord with volume 0.7
+--- note("c4", "e4 v0.5", "off") --> custom chord with a c4, e4 and 'off' note
 --- ```
 ---@param ... NoteValue
 ---@return Note
@@ -111,3 +111,16 @@ function Note:delay(delay) end
 ---@overload fun(table: NoteValue[]): Note
 ---@overload fun(...: NoteValue): Note
 function note(...) end
+
+---Convert a note string or note table to a raw MIDI note number in range 0-127
+---or -1 for nil or off note values.
+---### Examples:
+---```lua
+---note_value("c4") --> 48
+---note_value(note("c4")) --> 48
+---note_value("off") --> -1
+---note_value("xyz") --> error
+---```
+---@param note NoteValue
+---@return integer
+function note_number(note) end

--- a/types/nerdo/library/rhythm.lua
+++ b/types/nerdo/library/rhythm.lua
@@ -7,16 +7,18 @@ error("Do not try to execute this file. It's just a type definition file.")
 ----------------------------------------------------------------------------------------------------
 
 ---Optional trigger context passed to `pattern`, `gate` and 'emit' functions.
----Specifies which keyboard note triggered, if any, started the rhythm.
----
+---Specifies which keyboard note triggered, if any, started the rhythm and
+---info about other .
 ---@class TriggerContext
 ---
----Note value that triggered, started the rhythm, if any.
----@field trigger_note integer?
----Note volume that triggered, started the rhythm, if any.
----@field trigger_volume number?
----Note slice offset value that triggered, started the rhythm, if any.
----@field trigger_offset integer?
+---The note which triggered the rhythm or notes which are currently held down for monophonic 
+---rhythms:
+---For monophonic rhythms with `poly` mode disabled, this will contain all notes which
+---currently triggering the rhythm, in the order they got triggered. The last note stops
+---the rhythm.
+---For rhythms with `polyphonic` playback mode enabled, this will only contain a single note,
+---the note that triggered the rhythm, as each note starts a new rhythm instance.
+---@field triggers NoteTable[]?
 ---
 ---Current input parameter values, using parameter ids as keys
 ---and the actual parameter value as value.
@@ -99,12 +101,12 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---### examples:
 ---```lua
 ----- slightly off beat pulse
----unit = "beats", 
+---unit = "beats",
 ---resolution = 1.01
 ---```
 ---```lua
 ----- triplet
----unit = "1/16", 
+---unit = "1/16",
 ---resolution = 4/3
 ---```
 ---@field unit "ms"|"seconds"|"bars"|"beats"|"1/1"|"1/2"|"1/4"|"1/8"|"1/16"|"1/32"|"1/64"
@@ -157,7 +159,7 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---```
 ---@field inputs? InputParameter[]
 ---
----Specify the rhythmical pattern of the rhythm. With the default `gate` implementation, 
+---Specify the rhythmical pattern of the rhythm. With the default `gate` implementation,
 ---each pulse with a value of `1` or `true` will cause an event from the `emitter` property
 ---to be triggered in the emitters time unit. `0`, `false` or `nil` values do not trigger.
 ---
@@ -225,10 +227,10 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---
 ---Optional pulse train filter function or generator function which filters events between
 ---the pattern and emitter. By default a threshold gate, which passes all pulse values
----greater than zero. 
+---greater than zero.
 ---
----Custom function should returns true when a pattern pulse value should be passed, 
----and false when the emitter should be skipped.  
+---Custom function should returns true when a pattern pulse value should be passed,
+---and false when the emitter should be skipped.
 ---
 ---### examples:
 ---```lua
@@ -321,8 +323,8 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---  unit = "bars",
 ---  resolution = 4,
 ---  offset = 1,
----  emit = { 
----    note("c4'm"), 
+---  emit = {
+---    note("c4'm"),
 ---    note("g3'm7"):transpose({ 0, 12, 0, 0 })
 ---  }
 ---}
@@ -333,7 +335,7 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---return rhythm {
 ---  unit = "1/8",
 ---  pattern = { 1, { 0, 1 }, 0, 0.3, 0.2, 1, { 0.5, 0.1, 1 }, 0.5 },
----  gate = function(init_context) 
+---  gate = function(init_context)
 ---    local rand = math.randomstate(seed)
 ---    return function(context)
 ---      return context.pulse_value > rand()


### PR DESCRIPTION
Adds a new "mono" trigger mode to rhythm. 

"external_data" in context now is an explicit "trigger_event" which is passed down to Lua callbacks as polyphone note event.