### PR TITLE
Fix chained expressions

### DIFF
--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -63,21 +63,18 @@ op_degrade   = ${ "?" ~ number? }
 /// dynamic operators
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
+op_target    = { ":" ~ parameter }
 // this should actually use `parameter` as well once bjorklund with patterns on the right is implemented
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 
 /// all operators
-op           = _{ op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
+op           = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
 
 expression   = { (single | group) ~ op+ }
 
-/// target expressions allow expressions on both sides and take precendece over other expressions
-target_element = _{expression | single | group}
-targeted       = { target_element ~ (":" ~ target_element)+ }
-
 range      = ${ integer ~ ".." ~ integer }
 /// helper container that splits steps into sections
-section    = _{ ( targeted | expression | range | single | repeat | group)+ }
+section    = _{ ( expression | range | single | repeat | group)+ }
 
 /// the root of the cycle
 mini = { SOI ~ sections? ~ EOI }

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -52,7 +52,7 @@ polymeter       = { "{" ~ sections? ~ "}" ~ polymeter_tail? }
 group           = _{ subdivision | alternating | polymeter }
 
 /// parameter for expressions with operators
-parameter        = _{ expression | single | group }
+parameter        = _{ single | group }
 single_parameter = _{ single }
 
 /// static operators
@@ -60,10 +60,10 @@ op_replicate = ${ "!" ~ number }
 op_weight    = ${ "@" ~ number? }
 op_degrade   = ${ "?" ~ number? }
 
-/// dynamic operators (NB: only o_target can be chained)
+/// dynamic operators
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
-op_target    = { ":" ~ parameter ~ (":" ~ parameter)* }
+op_target    = { ":" ~ parameter }
 // this should actually use `parameter` as well once bjorklund with patterns on the right is implemented
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -63,17 +63,21 @@ op_degrade   = ${ "?" ~ number? }
 /// dynamic operators
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
-op_target    = { ":" ~ parameter }
 // this should actually use `parameter` as well once bjorklund with patterns on the right is implemented
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 
 /// all operators
-op           = _{ op_target | op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
+op           = _{ op_degrade | op_replicate | op_weight | op_fast | op_slow | op_bjorklund }
 
-expression = { (single | group) ~ op+ }
+expression   = { (single | group) ~ op+ }
+
+/// target expressions allow expressions on both sides and take precendece over other expressions
+target_element = _{expression | single | group}
+targeted       = { target_element ~ (":" ~ target_element)+ }
+
 range      = ${ integer ~ ".." ~ integer }
 /// helper container that splits steps into sections
-section    = _{ ( expression | range | single | repeat | group)+ }
+section    = _{ ( targeted | expression | range | single | repeat | group)+ }
 
 /// the root of the cycle
 mini = { SOI ~ sections? ~ EOI }

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1654,7 +1654,7 @@ impl Cycle {
         Ok(events)
     }
 
-    // helper to calculate the right multiplier for polymeter and dynamic expressions
+    // helper to calculate the right multiplier for polymeter and speed expressions
     fn step_multiplier(step: &Step, value: &Value) -> Fraction {
         match step {
             Step::Polymeter(pm) => {
@@ -1790,7 +1790,7 @@ impl Cycle {
     }
 
     // output a multiplied pattern expression with support for patterns on the right side
-    fn output_dynamic(
+    fn output_with_speed(
         right: &Step,
         step: &Step,
         state: &mut CycleState,
@@ -1914,7 +1914,7 @@ impl Cycle {
                 Self::output(&cs.choices[choice], state, cycle, limit)?
             }
             Step::Polymeter(pm) => {
-                Self::output_dynamic(pm.count.as_ref(), step, state, cycle, limit)?
+                Self::output_with_speed(pm.count.as_ref(), step, state, cycle, limit)?
             }
             Step::Stack(st) => {
                 if st.stack.is_empty() {
@@ -1946,7 +1946,7 @@ impl Cycle {
                 Self::output_with_target(e.left.as_ref(), e.right.as_ref(), state, cycle, limit)?
             }
             Step::SpeedExpression(e) => {
-                Self::output_dynamic(e.right.as_ref(), step, state, cycle, limit)?
+                Self::output_with_speed(e.right.as_ref(), step, state, cycle, limit)?
             }
             Step::Bjorklund(b) => {
                 let mut events = vec![];


### PR DESCRIPTION
Chained expressions were generating unexpectedly thrown away results thanks to the way they were parsed, fixing that here.

Also did a bit of cleanup by separated the Target, Bjorklund and Degrade operators from Dynamic/Dynamic Op/Expression, as they were treated special anyway, this makes the types better reflect the behaviour and leads to a bit less branching at the cost of a few more types.

A few more test cases would be nice to add before merge.