### PR TITLE
Target assignment, refactor, fixes

### DIFF
--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -13,8 +13,8 @@
 > * Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
 > * `:` sets the instrument or remappable target instead of selecting samples but also 
 >   allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
-> * In bjorklund expressions, operators *within* and on the *right side* are not supported
->   (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
+> * In bjorklund expressions, operators *within* are not supported
+>   (e.g. `bd(<3 2>, 8)` is *not* supported)
 > 
 > [Tidal Cycles Reference](https://tidalcycles.org/docs/reference/mini_notation/)
 > 

--- a/docs/src/guide/cycles.md
+++ b/docs/src/guide/cycles.md
@@ -76,7 +76,7 @@ There's no exact specification for how tidal cycles work, and it's constantly ev
 
 * `:` sets the instrument or remappable target instead of selecting samples but also allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 
-* In bjorklund expressions, operators *within* and on the *right side* are not supported (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
+* In bjorklund expressions, operators *within* are not supported (e.g. `bd(<3 2>, 8)` is *not* supported)
 
 ### Timing 
 
@@ -86,7 +86,7 @@ The base time of a pattern in tidal is specified as *cycles per second*. In afse
 -- emits an entire cycle every beat
 return rhythm {
   unit = "beats",
-  emit = cycle("c4 d4 e4") -- tripplet
+  emit = cycle("c4 d4 e4") -- triplet
 }
 ```
 
@@ -140,6 +140,28 @@ Supported note attributes are:
 - Delay: `:dX` - with X \[0.0-1.0\)
 
 Note that `X` must be written as *floating point number* for volume, panning and delay:</br> `c4:p-1.0` and `c4:p.8` is valid, while `c4:p-1` **is not valid**!
+
+If you want to use expressions (like slowing down) for an attribute pattern on the right side, you'll have to wrap it in square brackets, otherwise the expression applies to the entire pattern, not just the attributes'.
+
+```lua
+-- This slows down the output
+cycle("[c4 d#4 e4]:<v.1 v.2>/2")
+
+-- This slows down the alternating for the volume
+cycle("[c4 d#4 e4]:[<v.1 v.2>/2]")
+  
+```
+
+A shorthand for assigning attributes exists in the form of `:v=X` where `X` can be a pattern. This way, you can supply float values without having to repeat the name of the target attribute.
+
+```lua
+-- Set volume to rise for each cycle
+cycle("[c4 d#4 e4]:v=<.1 .2 .3 .4>")
+
+-- This would be the same as
+cycle("[c4 d#4 e4]:<v.1 v.2 v.3 v.4>")
+```
+
 
 ### Mapping
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,7 @@ pub use event::{
 
 pub mod tidal;
 pub use tidal::{
-    Cycle, Event as CycleEvent, PropertyKey as CyclePropertyKey,
-    PropertyValue as CyclePropertyValue, Span as CycleSpan, Target as CycleTarget,
-    Value as CycleValue,
+    Cycle, Event as CycleEvent, Span as CycleSpan, Target as CycleTarget, Value as CycleValue,
 };
 
 pub mod pulse;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -27,8 +27,6 @@ pub use super::{
     Chord,
     Cycle,
     CycleEvent,
-    CyclePropertyKey,
-    CyclePropertyValue,
     CycleSpan,
     CycleTarget,
     CycleValue,

--- a/src/tidal.rs
+++ b/src/tidal.rs
@@ -1,4 +1,4 @@
 //! Tidal mini parser and event generator, used as `EventIter`.
 
 mod cycle;
-pub use cycle::{Cycle, Event, Pitch, PropertyKey, PropertyValue, Span, Target, Value};
+pub use cycle::{Cycle, Event, Pitch, Span, Target, Value};

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -17,6 +17,9 @@ pitch   = ${ note ~ mark? ~ octave? ~ !name}
 
 /// target properties such as volume "v0.1" (afseq extension)
 target = ${ ("#" ~ integer) | (ASCII_ALPHA ~ float) }
+/// patterns for assigning target keys with pattern on the right side
+target_name = ${ "#" | name }
+target_assign = { target_name ~ "=" ~ parameter }
 
 /// chord as pitch with mode string, separated via "'"
 mode    = ${ (ASCII_ALPHANUMERIC | "#" | "-" | "+" | "^")+ }
@@ -63,7 +66,7 @@ op_degrade   = ${ "?" ~ number? }
 /// dynamic operators
 op_fast      = { "*" ~ parameter }
 op_slow      = { "/" ~ parameter }
-op_target    = { ":" ~ parameter }
+op_target    = { ":" ~ (target_assign | parameter) }
 // this should actually use `parameter` as well once bjorklund with patterns on the right is implemented
 op_bjorklund = { "(" ~ (single_parameter ~ ",")+ ~ single_parameter ~ ")" }
 

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -15,8 +15,8 @@ mark    = { "#"|"b" }
 note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
 pitch   = ${ note ~ mark? ~ octave? ~ !name}
 
-// target properties such as volume "v0.1" (afseq extension)
-property = ${ ("#" ~ integer) | (ASCII_ALPHA ~ float) }
+/// target properties such as volume "v0.1" (afseq extension)
+target = ${ ("#" ~ integer) | (ASCII_ALPHA ~ float) }
 
 /// chord as pitch with mode string, separated via "'"
 mode    = ${ (ASCII_ALPHANUMERIC | "#" | "-" | "+" | "^")+ }
@@ -34,7 +34,7 @@ name = @{ ASCII_ALPHANUMERIC ~ (ASCII_ALPHANUMERIC | "_")* }
 repeat = { "!" }
 
 /// possible literals for single steps
-single = { hold | rest | chord | property | pitch | number | name }
+single = { hold | rest | chord | target | pitch | number | name }
 
 choice_op = {"|"}
 stack_op = {","}

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1615,13 +1615,18 @@ impl CycleParser {
         if let Some(name) = key.next() {
             pattern.mutate_singles(&mut |single: &mut Single| {
                 if let Some(f) = single.value.to_float() {
-                    single.value = Value::Target(Target::Named(Rc::from(name.as_str()), Some(f)));
+                    if !matches!(single.value, Value::Target(_)) {
+                        single.value =
+                            Value::Target(Target::Named(Rc::from(name.as_str()), Some(f)));
+                    }
                 }
             });
         } else {
             pattern.mutate_singles(&mut |single: &mut Single| {
                 if let Some(i) = single.value.to_integer() {
-                    single.value = Value::Target(Target::Index(i));
+                    if !matches!(single.value, Value::Target(_)) {
+                        single.value = Value::Target(Target::Index(i));
+                    }
                 }
             });
         }
@@ -3096,6 +3101,11 @@ mod test {
                         ]),
                 ]],
             ],
+        )?;
+
+        assert_cycle_equality(
+            "[1 2 3 4]:v=[0.2 0.3 0.4 p.8]",
+            "[1 2 3 4]:[v0.2 v0.3 v0.4 p.8]",
         )?;
         Ok(())
     }


### PR DESCRIPTION
### refactoring Target

The `PropertyKey` stuff bugged me because it could express a lot of impossible values like an `Index` with something on the right, or a `Name` with `Integer` value and the fact that `#` name was treated as `Index`, so I simplified this as

```rust
Target {
  Index(i32),
  Named(Rc<str>, Option<f64>)
}
```
Cause this is actually what we have. Additionally, `#` name is parsed as `Index` instead of making it out of the parser as `Named`. If needed we can extend what can be on the right side of `Named` later, but using an `f64` is enough for now imo.

### assigning target patterns

Implemented assignment for targeting using `=`, to allow for easier typing targets like

```
[a b c d]:v=[.1 .2 .3 .4]
```

As per rules of expression chaining (ie no precedence rules, just nesting left to right), if one wants an expression for `v` here, the pattern need to be wrapped in `[]`. 

```
[a b c d]:v=[[.1 .2 .3 .4]/2]
```

Indices work without this ofc but you can still make it more verbose with `#`, ie
```
[a b c d]:[1 2 3 4]
same as
[a b c d]:#=[1 2 3 4]
```

With this, longer names can also be used (although these still need to be handled somehow outside of the cycle module):
```
[a b c d]:custom_param=<.2 .5 .8>
```

### cropping

for target pattern overlapping (both the new assignment and the regular one) events should be cropped inclusively instead of dropping them when they start in the previous cycle, this required a somewhat ugly solution of carrying an `overlap` flag through the output functions, hopefully this doesn't matter much for performance. Below tried to illustrate the problem:

example
```
input      "[a b c d]:[[v.1 v.2 v.3 v.4]/3]"
cycle bounds   |1              |2              |3
step pattern   |a  |b  |c  |d  |a  |b  |c  |d  |a ...
target pattern |.1         |.2         |.3        |.4 
         default crop ------>  |
                               ^v.2^ 
                              a and b here need v.2 but it would be cropped out of the cycle
```

### holds

Target patterns were not applying holds, this is fixed now, meaning `[a b c d]:[1 _ _ 2]` now correctly generates `[a:1 b:1 c:1 d:2]`.