### PR TITLE
Mirror playground script in URL hash

### DIFF
--- a/examples/playground/web/app.css
+++ b/examples/playground/web/app.css
@@ -182,8 +182,33 @@ code {
     font-size: larger;
 }
 
-.transport>#stopButton {
-    font-size: larger;
+.toggleButton {
+    background-color: transparent;
+    color: var(--color-text);
+}
+
+.toggleButton:hover {
+    color: var(--color-accent);
+    background-color: var(--color-bg);
+}
+
+.toggleButton:disabled:hover {
+    background-color: transparent;
+    color: var(--color-grid);
+    cursor: not-allowed;
+}
+
+.toggleButton.enabled {
+    background-color: var(--color-accent);
+    color: var(--color-bg);
+}
+
+#midiButton.enabled #blackKeys {
+    fill: var(--color-accent);
+}
+#midiButton.enabled #whiteKeys {
+    fill: var(--color-bg);
+    stroke: var(--color-accent);
 }
 
 .bpm-control {

--- a/examples/playground/web/index.html
+++ b/examples/playground/web/index.html
@@ -52,14 +52,13 @@
         </div>
 
         <div class="transport">
-            <button id="playButton" title="Start playback"><i class="fas fa-play"></i></button>
-            <button id="stopButton" title="Stop playback"><i class="fas fa-stop"></i></button>
-            <button id="midiButton" title="Play scripts polyphonically with MIDI Input">
+            <button id="playButton" class="toggleButton"><i class="fas fa-play"></i></button>
+            <button id="midiButton" class="toggleButton" title="Play scripts polyphonically with MIDI Input">
                 <svg width="40" height="14" viewBox="10 0 62 20" xmlns="http://www.w3.org/2000/svg">
                     <path
                         d="M10 0h8v20h-8zm9 0h8v20h-8zm9 0h8v20h-8zm9 0h8v20h-8zm9 0h8v20h-8zm9 0h8v20h-8zm9 0h8v20h-8z"
-                        fill="currentColor" stroke="black" stroke-width="0.5" />
-                    <path d="M15 0h6v12h-6zm9 0h6v12h-6zm18 0h6v12h-6zm9 0h6v12h-6zm9 0h6v12h-6z" fill="black" />
+                        id="whiteKeys" fill="currentColor" stroke="black" stroke-width="0.5" />
+                    <path id="blackKeys" d="M15 0h6v12h-6zm9 0h6v12h-6zm18 0h6v12h-6zm9 0h6v12h-6zm9 0h6v12h-6z" fill="black" />
                 </svg>
             </button>
 


### PR DESCRIPTION
A feature that is present on many livecoding sites, encoding the script you write into the URL hash using a base64 string as you type, so that it is easy to share a script by simply copy-pasting the link.

Wrapping the script into an object here so that created links stay future proof in case we want to add encoding more states like the default sample, parameter values or something else besides the script string later.

Overall, not the most elegant thing but it proved useful on other sites like this and it is easy to implement.