### PR TITLE
fix inverse behaviour for sample assignment in cycles

### DIFF
--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -2708,7 +2708,7 @@ mod test {
                             .with_target(Target::from_index(1)),
                         Event::at(Fraction::new(1, 2), Fraction::new(1, 4))
                             .with_note(11, 4)
-                            .with_targets(vec![Target::from_index(7)]),
+                            .with_target(Target::from_index(7)),
                         Event::at(Fraction::new(3, 4), Fraction::new(1, 4))
                             .with_note(11, 4)
                             .with_target(Target::from_index(9)),


### PR DESCRIPTION
So it seems like I've missed this when discussing #54 and haven't actually used sample properties much but I feel that this should actually work the same way as the other assignments.

Right now, the outer index overrides the inner one, which is the opposite of what happens with volumes and the rest. 

If multiple assigned samples could stack when playing maybe this would make more sense (but there is already stacking syntax so that's not as useful).

Of course, this is a breaking change but I think one that may not have been used much and that [arguably](https://github.com/renoise/pattrns/issues/31#issuecomment-2231935639) makes the notation more useful *and* consistent. I'd consider the current implementation a bug.