### PR TITLE
playground url fixes

### DIFF
--- a/examples/playground/web/app.js
+++ b/examples/playground/web/app.js
@@ -273,16 +273,13 @@ const app = {
 
     _getUserBpm: function () {
         const bpm = parseInt(this._bpmInput.value);
-        console.log(this._bpmInput)
         if (!isNaN(bpm)) {
             const clampedBpm = Math.max(this._bpmInput.min, Math.min(bpm, this._bpmInput.max));
             if (bpm !== clampedBpm) {
                 this._bpmInput.value = clampedBpm;
             }
-          console.log("returning deefault bpm")
             return clampedBpm;
         } else {
-          console.log("returning deefault bpm")
             return defaultBpm;
         }
     },


### PR DESCRIPTION
In response to #96 
* fixing the issue with history being spammed when the user edits the script
* highlighting a loaded example's link if the loaded data has it as name
* fixing navigating back to the default script at `/`
* also added storing/loading the bpm which is useful for sharing custom scripts to have them sound the same

It might be better to transition to using search params instead of everything encoded into the hash, but this also works.

The alternative could make urls be like
```
pattrns.renoise.com?example=some-example&bpm=120&instrument=1&script=bAsE64eNcOdEdScRiPt...
```

We could then treat examples uniquely from other scripts in that the code contents wouldn't be put into the url and it would be human readable with the slug of the example being in the url verbatim. Do we need this?