### PR TITLE
Allow creating note user data from note integer strings

### DIFF
--- a/src/bindings/note.rs
+++ b/src/bindings/note.rs
@@ -293,6 +293,7 @@ mod test {
         // Note string
         assert!(evaluate_note_userdata(&lua, r#"note("X#1")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("0.5")"#).is_err());
+        assert!(evaluate_note_userdata(&lua, r#"note("0xfff")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("C#1 -0.5")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("C#1", 0.5)"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("C#1")"#).is_ok());
@@ -340,8 +341,18 @@ mod test {
         let note_event = evaluate_note_userdata(&lua, r#"note(0x32)"#)?;
         assert_eq!(note_event.notes, vec![new_note("d4")]);
 
+        // Note int string
+        let note_event = evaluate_note_userdata(&lua, r#"note("32")"#)?;
+        assert_eq!(note_event.notes, vec![new_note("g#2")]);
+        let note_event = evaluate_note_userdata(&lua, r#"note("0x32")"#)?;
+        assert_eq!(note_event.notes, vec![new_note("d4")]);
+
         // Note int array
         let note_event = evaluate_note_userdata(&lua, r#"note({0x32, 48})"#)?;
+        assert_eq!(note_event.notes, vec![new_note("d4"), new_note("c4")]);
+
+        // Note int string array
+        let note_event = evaluate_note_userdata(&lua, r#"note({"0X32", "48"})"#)?;
         assert_eq!(note_event.notes, vec![new_note("d4"), new_note("c4")]);
 
         // Note table
@@ -353,6 +364,10 @@ mod test {
         assert_eq!(note_event.notes, vec![new_note("c8")]);
         let note_event = evaluate_note_userdata(&lua, r#"note({key = "G8", volume = 0.5})"#)?;
         assert_eq!(note_event.notes, vec![new_note(("g8", None, None, 0.5))]);
+        let note_event = evaluate_note_userdata(&lua, r#"note({key = 60})"#)?;
+        assert_eq!(note_event.notes, vec![new_note("c5")]);
+        let note_event = evaluate_note_userdata(&lua, r#"note({key = "60"})"#)?;
+        assert_eq!(note_event.notes, vec![new_note("c5")]);
 
         // Note table or array
         let poly_note_event = evaluate_note_userdata(
@@ -392,6 +407,7 @@ mod test {
         // Note chord
         assert!(evaluate_note_userdata(&lua, r#"note("c12'maj")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("j'maj")"#).is_err());
+        assert!(evaluate_note_userdata(&lua, r#"note("128'maj")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("c4'invalid")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("c4'maj'")"#).is_err());
         assert!(evaluate_note_userdata(&lua, r#"note("c4'maj xx")"#).is_err());
@@ -403,6 +419,14 @@ mod test {
 
         assert_eq!(
             evaluate_note_userdata(&lua, r#"note("c'maj")"#)?.notes,
+            vec![new_note("c4"), new_note("e4"), new_note("g4"),]
+        );
+        assert_eq!(
+            evaluate_note_userdata(&lua, r#"note("60'maj")"#)?.notes,
+            vec![new_note("c5"), new_note("e5"), new_note("g5"),]
+        );
+        assert_eq!(
+            evaluate_note_userdata(&lua, r#"note("0x30'maj")"#)?.notes,
             vec![new_note("c4"), new_note("e4"), new_note("g4"),]
         );
         assert_eq!(

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -556,14 +556,22 @@ pub(crate) fn note_degree_from_value(arg: &LuaValue, arg_index: usize) -> LuaRes
     }
 }
 
-pub(crate) fn note_event_from_number(note_value: LuaInteger) -> LuaResult<Option<NoteEvent>> {
+pub(crate) fn note_from_number(note_value: LuaInteger) -> LuaResult<Note> {
     match note_value {
-        0..=0x7f | 0xFE | 0xFF => Ok(new_note(note_value as u8)),
+        0..=0x7f | 0xFE | 0xFF => Ok(Note::from(note_value as u8)),
         _ => Err(LuaError::RuntimeError(format!(
-            "note number must be 0xFF for empty notes or 0xFE for off notes or must be in range [0..=0x7f], but is: '{}'",
+            "note number must be 0xFF (empty note) or 0xFE (off note) or in range [0..=127], but is: '{}'",
             note_value
         ))),
     }
+}
+
+pub(crate) fn note_event_from_number(note_value: LuaInteger) -> LuaResult<Option<NoteEvent>> {
+    Ok(new_note(note_from_number(note_value)?))
+}
+
+pub(crate) fn note_from_string(note_string: &str) -> Result<Note, LuaError> {
+    Note::try_from(note_string).map_err(|err| LuaError::RuntimeError(err.to_string()))
 }
 
 pub(crate) fn note_event_from_string(str: &str) -> LuaResult<Option<NoteEvent>> {
@@ -572,8 +580,7 @@ pub(crate) fn note_event_from_string(str: &str) -> LuaResult<Option<NoteEvent>> 
     if is_empty_note_string(note_part) {
         Ok(None)
     } else {
-        let note =
-            Note::try_from(note_part).map_err(|err| LuaError::RuntimeError(err.to_string()))?;
+        let note = note_from_string(note_part)?;
         let mut instrument = None;
         let mut volume = 1.0;
         let mut panning = 0.0;


### PR DESCRIPTION
fixes #98 

Using note strings such as `note("48")` or even `note("48'maj")` maybe isn't very useful, but it is in line with Lua's implicit conversion of strings to numbers, for example: `"10" + 2` 