### PR TITLE
user variables for scripted cycles

### DIFF
--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -230,7 +230,7 @@
 > step length fraction within the cycle, where 1 is the total duration of a single cycle run.
 
 ### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
-> Note that triggered the pattern, if any. Usually will ne a monophic note.
+> Note that triggered the pattern, if any. Usually will be a monophonic note.
 > To access the raw note number value use: `context.trigger.notes[1].key`
 
 ### parameter : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="parameter"></a>
@@ -279,7 +279,7 @@
 > Starts from 1 when the cycle starts running or after it got reset.
 
 ### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
-> Note that triggered the pattern, if any. Usually will ne a monophic note.
+> Note that triggered the pattern, if any. Usually will be a monophonic note.
 > To access the raw note number value use: `context.trigger.notes[1].key`
 
 ### parameter : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="parameter"></a>

--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -275,7 +275,8 @@
 > Specifies how the cycle currently is running.
 
 ### iteration : [`integer`](../API/builtins/integer.md)<a name="iteration"></a>
-> how often the cycle has been run.
+> Iteration counter for the cycle that increases once per the whole cycle's output
+> Starts from 1 when the cycle starts running or after it got reset.
 
 ### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
 > Note that triggered the pattern, if any. Usually will ne a monophic note.

--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -11,7 +11,7 @@
 > 
 > `cycle` accepts a mini-notation as used by Tidal Cycles, with the following differences:
 > * Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
-> * `:` sets the instrument or remappable target instead of selecting samples but also 
+> * `:` sets the instrument or remappable target instead of selecting samples but also
 >   allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 > * In bjorklund expressions, operators *within* and on the *right side* are not supported
 >   (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)
@@ -52,6 +52,22 @@
 [`NoteValue`](#NoteValue) | [`NoteValue`](#NoteValue)[]  
   
   
+### CycleMapTable<a name="CycleMapTable"></a>
+{  }  
+  
+  
+### CycleVarFunction<a name="CycleVarFunction"></a>
+(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` [`CycleVarTable`](#CycleVarTable)  
+  
+  
+### CycleVarGenerator<a name="CycleVarGenerator"></a>
+(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` [`CycleVarFunction`](#CycleVarFunction)  
+  
+  
+### CycleVarTable<a name="CycleVarTable"></a>
+{  }  
+  
+  
 ### NoteValue<a name="NoteValue"></a>
 [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md) | [`Note`](../API/note.md#Note) | [`NoteTable`](../API/note.md#NoteTable) | [`nil`](../API/builtins/nil.md)  
   
@@ -74,7 +90,7 @@
 
 ---  
 ## Functions
-### map([*self*](../API/builtins/self.md), map : [`CycleMapFunction`](#CycleMapFunction) | [`CycleMapGenerator`](#CycleMapGenerator) | {  })<a name="map"></a>
+### map([*self*](../API/builtins/self.md), map : [`CycleMapFunction`](#CycleMapFunction) | [`CycleMapGenerator`](#CycleMapGenerator) | [`CycleMapTable`](#CycleMapTable))<a name="map"></a>
 `->`[`Cycle`](../API/cycle.md#Cycle)  
 
 > Map names in in the cycle to custom note events.
@@ -126,32 +142,24 @@
 >   end
 > end)
 > ```
-
-### var([*self*](../API/builtins/self.md), vars : [`CycleVarFunction`](#CycleVarFunction) | {  })<a name="var"></a>
+### var([*self*](../API/builtins/self.md), variables : [`CycleVarFunction`](#CycleVarFunction) | [`CycleVarGenerator`](#CycleVarGenerator) | [`CycleVarTable`](#CycleVarTable))<a name="var"></a>
 `->`[`Cycle`](../API/cycle.md#Cycle)  
 
-> Assign variables to be used inside the cycle (with `$` prefix).
+> Assign variables to be used inside the main cycle script via `$name` notation
 > 
-> By default the parameters you define will get assigned as variables by their name,
-> but you can also declare (or override) such variables by supplying a table to `var`,
-> or using a callback that returns a table.
-> Callbacks receive a context with parameters and an iteration counter.
+> By default any parameter you define will be available to the cycle as a variable
+> but you can override and declare additional variables by passing in a table of them
+> or passing a function that returns such a table.
 > 
 > #### examples:
 > ```lua
-> --Using a static table for variables
-> cycle("bd $r $r $r"):var({
->   r = "[a b c]",
+> --Using a static table
+> cycle("$a $a $b $a $b $b"):var({
+>   a = "c a f e"
+>   b = "e f a c"
 > })
-> ```
-> ```lua
-> --Using a callback to generate variables
-> cycle("c $r"):var(function(context)
->    return {
->      r = context.iteration == 1 and "a*4" or "[a b c]"
->    }
-> end)
-> ```
+> ```  
+
 
 
 ---  
@@ -166,6 +174,22 @@
   
 ### CycleMapNoteValue<a name="CycleMapNoteValue"></a>
 [`NoteValue`](#NoteValue) | [`NoteValue`](#NoteValue)[]  
+  
+  
+### CycleMapTable<a name="CycleMapTable"></a>
+{  }  
+  
+  
+### CycleVarFunction<a name="CycleVarFunction"></a>
+(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` [`CycleVarTable`](#CycleVarTable)  
+  
+  
+### CycleVarGenerator<a name="CycleVarGenerator"></a>
+(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` [`CycleVarFunction`](#CycleVarFunction)  
+  
+  
+### CycleVarTable<a name="CycleVarTable"></a>
+{  }  
   
   
 ### NoteValue<a name="NoteValue"></a>
@@ -183,6 +207,9 @@
 >     | "running"
 > ```  
   
+
+
+
 # CycleMapContext<a name="CycleMapContext"></a>  
 > Context passed to 'cycle:map` functions.  
 
@@ -237,9 +264,6 @@
 > ```  
   
 
----
-### CycleVarFunction<a name="CycleVarFunction"></a>
-(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` { }
 
 
 # CycleVarContext<a name="CycleVarContext"></a>  
@@ -247,10 +271,46 @@
 
 ---  
 ## Properties
+### playback : [`PlaybackState`](#PlaybackState)<a name="playback"></a>
+> Specifies how the cycle currently is running.
+
+### iteration : [`integer`](../API/builtins/integer.md)<a name="iteration"></a>
+> how often the cycle has been run.
+
+### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
+> Note that triggered the pattern, if any. Usually will ne a monophic note.
+> To access the raw note number value use: `context.trigger.notes[1].key`
+
 ### parameter : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="parameter"></a>
 > Current parameter values: parameter ids are keys, parameter values are values.
 > To access a parameter with id `enabled` use: `context.parameter.enabled`
 
-### iteration : [`integer`](../API/builtins/integer.md)<a name="iteration"></a>
-> Iteration counter for the cycle that increases once per the whole cycle's output
-> Starts from 1 when the cycle starts running or after it got reset.
+### beats_per_min : [`number`](../API/builtins/number.md)<a name="beats_per_min"></a>
+> Project's tempo in beats per minutes.
+
+### beats_per_bar : [`integer`](../API/builtins/integer.md)<a name="beats_per_bar"></a>
+> Project's beats per bar settings - usually will be 4.
+
+### samples_per_sec : [`integer`](../API/builtins/integer.md)<a name="samples_per_sec"></a>
+> Project's audio playback sample rate in samples per second.
+
+  
+
+
+
+---  
+## Aliases  
+### PlaybackState<a name="PlaybackState"></a>
+`"running"` | `"seeking"`  
+> ```lua
+> -- - *seeking*: The pattern is auto-seeked to a target time. All events are discarded. Avoid
+> --   unnecessary computations while seeking, and only maintain your generator's internal state.
+> -- - *running*: The pattern is played back regularly. Events are emitted and audible.
+> PlaybackState:
+>     | "seeking"
+>     | "running"
+> ```  
+  
+
+
+

--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -125,8 +125,31 @@
 >     return note(cmin:chord(tonumber(value)))
 >   end
 > end)
-> ```  
+> ```
 
+### var([*self*](../API/builtins/self.md), vars : [`CycleVarFunction`](#CycleVarFunction) | {  })<a name="var"></a>
+`->`[`Cycle`](../API/cycle.md#Cycle)  
+
+> Assign variables to be used inside the cycle (with `$` prefix).
+> 
+> By default the parameters you set on the pattern will get assigned as variables by their name,
+> but you can also define static variables by supplying a table to `var` or create the same via a callback.
+> 
+> #### examples:
+> ```lua
+> --Using a static table for variables
+> cycle("bd $r $r $r"):var({
+>   r = "[a b c]",
+> })
+> ```
+> ```lua
+> --Using a callback to generate variables
+> cycle("c $r"):var(function(context)
+>    return {
+>      r = context.iteration == 1 and "a*4" or "[a b c]"
+>    }
+> end)
+> ```
 
 
 ---  
@@ -158,9 +181,6 @@
 >     | "running"
 > ```  
   
-
-
-
 # CycleMapContext<a name="CycleMapContext"></a>  
 > Context passed to 'cycle:map` functions.  
 
@@ -215,5 +235,20 @@
 > ```  
   
 
+---
+### CycleVarFunction<a name="CycleVarFunction"></a>
+(context : [`CycleVarContext`](../API/cycle.md#CycleVarContext)) `->` { }
 
 
+# CycleVarContext<a name="CycleVarContext"></a>  
+> Context passed to 'cycle:var` functions.  
+
+---  
+## Properties
+### parameter : table<[`string`](../API/builtins/string.md), [`boolean`](../API/builtins/boolean.md) | [`string`](../API/builtins/string.md) | [`number`](../API/builtins/number.md)><a name="parameter"></a>
+> Current parameter values: parameter ids are keys, parameter values are values.
+> To access a parameter with id `enabled` use: `context.parameter.enabled`
+
+### iteration : [`integer`](../API/builtins/integer.md)<a name="iteration"></a>
+> Iteration counter for the cycle that increases once per the whole cycle's output
+> Starts from 1 when the cycle starts running or after it got reset.

--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -132,8 +132,10 @@
 
 > Assign variables to be used inside the cycle (with `$` prefix).
 > 
-> By default the parameters you set on the pattern will get assigned as variables by their name,
-> but you can also define static variables by supplying a table to `var` or create the same via a callback.
+> By default the parameters you define will get assigned as variables by their name,
+> but you can also declare (or override) such variables by supplying a table to `var`,
+> or using a callback that returns a table.
+> Callbacks receive a context with parameters and an iteration counter.
 > 
 > #### examples:
 > ```lua

--- a/docs/src/guide/cycles.md
+++ b/docs/src/guide/cycles.md
@@ -190,6 +190,58 @@ return cycle("[bd*4], [_ sn]*2"):map(function(context, value)
 end)
 ```
 
+### Parameters and variables
+
+The [parameters](./parameters.md) you define will be made available for use inside the cycle string by adding `$` to the beginning of the name you used to create a parameter.
+
+```lua
+return pattern {
+  parameter = {
+    parameter.integer("repeat", 1, {1, 16})
+  },
+  -- every new cycle generated will be affected by
+  -- the current value of the repeat parameter
+  event = cycle("a*$repeat")
+}
+```
+
+When using [`enum`](../API/parameter.md#enum) parameters you can use entire cycles to be injected into a main cycle, which is handy for reusing and changing patterns on the fly.
+
+> Note, the cycles assigned to variables cannot contain other variables inside them
+
+```lua
+return pattern {
+  parameter = {
+    parameter.enum("part", "a", {
+      "a",
+      "a _ e ~",
+      "a e*3 a ~",
+      "<a e f> _ <f g a c> ~",
+    }),
+    parameter.enum("other", "c", {
+      "c",
+      "<c d>",
+      "[a g f e]/2 c",
+      "[b a g f]/2 e",
+    })
+  },
+  -- combine two monophonic parts together
+  -- and reuse the same thing at a different speed
+  event = cycle("$part, $other/4, ~ $other/16")
+}
+```
+
+If you want to use variables other than parameters, you can declare your own with the [`var`](../API/cycle.md#var) method on the result of `cycle`. This works similar to `map`, in that you can either supply a table with the desired variables or a function that returns a table, the latter will be called every time the cycle is used to generate a new batch of events.
+
+```lua
+return pattern {
+  event = cycle("[$note*3 $note*4 $note $note]:$instrument"):var({ note = "d3", instrument = 2 })
+}
+```
+
+TODO add function example
+
+
 ## Advanced Examples
 
 Chord progression 

--- a/docs/src/guide/cycles.md
+++ b/docs/src/guide/cycles.md
@@ -239,6 +239,19 @@ return pattern {
 }
 ```
 
+You can also assign variables dynamically by supplying a callback to [`var`](../API/cycle.md#var), the callback will be called at every iteration of the cycle, you can access the index of the iteration on the `context` argument. Note, parameters you define will be assigned to variables as above, but you can override these with your callback.
+
+```lua
+return pattern {
+  parameter = {
+    parameter.integer("mult", 1, { 1, 8 })
+  },
+  event = cycle("a b*$mult"):var(function(context)
+    return { mult = context.parameter.mult * context.iteration }
+  end)
+}
+```
+
 TODO add function example
 
 

--- a/docs/src/guide/cycles.md
+++ b/docs/src/guide/cycles.md
@@ -252,8 +252,6 @@ return pattern {
 }
 ```
 
-TODO add function example
-
 
 ## Advanced Examples
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -51,7 +51,9 @@ pub use callback::{
 // internal re-exports
 pub(crate) use callback::{ContextPlaybackState, LuaCallback};
 pub(crate) use timeout::LuaTimeoutHook;
-pub(crate) use unwrap::{gate_trigger_from_value, note_events_from_value, pulse_from_value};
+pub(crate) use unwrap::{
+    assign_cycle_vars_from_table, gate_trigger_from_value, note_events_from_value, pulse_from_value,
+};
 
 // ---------------------------------------------------------------------------------------------
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -52,7 +52,7 @@ pub use callback::{
 pub(crate) use callback::{ContextPlaybackState, LuaCallback};
 pub(crate) use timeout::LuaTimeoutHook;
 pub(crate) use unwrap::{
-    assign_cycle_vars_from_table, gate_trigger_from_value, note_events_from_value, pulse_from_value,
+    gate_trigger_from_value, note_events_from_value, pulse_from_value, subcycle_values_from_table,
 };
 
 // ---------------------------------------------------------------------------------------------

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -387,7 +387,7 @@ impl LuaCallback {
     ) -> LuaResult<()> {
         self.set_context_playback_state(playback_state)?;
         self.set_context_time_base(time_base)?;
-        self.set_context_parameters(&parameters)?;
+        self.set_context_parameters(parameters)?;
         self.set_context_cycle_iteration(iteration)?;
         Ok(())
     }

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -251,10 +251,10 @@ impl LuaCallback {
     }
 
     /// Sets parameter context for the callback.
-    pub fn set_context_parameters(&mut self, parameters: ParameterSet) -> LuaResult<()> {
+    pub fn set_context_parameters(&mut self, parameters: &ParameterSet) -> LuaResult<()> {
         let inputs_context = &mut self.context.borrow_mut::<CallbackContext>()?.inputs_context;
         let mut parameters_map = HashMap::new();
-        for parameter in &parameters {
+        for parameter in parameters {
             let parameter = Rc::clone(parameter);
             let parameter_id = parameter.borrow().id().as_bytes().to_vec();
             parameters_map.insert(parameter_id, parameter);
@@ -309,8 +309,15 @@ impl LuaCallback {
     ) -> LuaResult<()> {
         let values = &mut self.context.borrow_mut::<CallbackContext>()?.values;
         values.insert(b"channel", (channel + 1).into());
-        values.insert(b"step", (step + 1).into());
+        values.insert(b"step", step.wrapping_add(1).into());
         values.insert(b"step_length", step_length.into());
+        Ok(())
+    }
+
+    /// Sets the cycle context iteration value for the callback.
+    pub fn set_context_cycle_iteration(&mut self, iteration: u32) -> LuaResult<()> {
+        let values = &mut self.context.borrow_mut::<CallbackContext>()?.values;
+        values.insert(b"iteration", iteration.wrapping_add(1).into());
         Ok(())
     }
 
@@ -355,7 +362,7 @@ impl LuaCallback {
         Ok(())
     }
 
-    /// Sets the cycle context for the mapping callback.
+    /// Sets the cycle context for the mapping callbacks.
     pub fn set_cycle_map_context(
         &mut self,
         playback_state: ContextPlaybackState,
@@ -370,15 +377,18 @@ impl LuaCallback {
         Ok(())
     }
 
-    /// Sets the cycle context for the variables callback.
+    /// Sets the cycle context for var callbacks.
     pub fn set_cycle_var_context(
         &mut self,
-        parameters: ParameterSet,
+        playback_state: ContextPlaybackState,
+        time_base: &BeatTimeBase,
+        parameters: &ParameterSet,
         iteration: u32,
     ) -> LuaResult<()> {
-        self.set_context_parameters(parameters)?;
-        let values = &mut self.context.borrow_mut::<CallbackContext>()?.values;
-        values.insert(b"iteration", (iteration.wrapping_add(1)).into());
+        self.set_context_playback_state(playback_state)?;
+        self.set_context_time_base(time_base)?;
+        self.set_context_parameters(&parameters)?;
+        self.set_context_cycle_iteration(iteration)?;
         Ok(())
     }
 

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -355,8 +355,8 @@ impl LuaCallback {
         Ok(())
     }
 
-    /// Sets the cycle context for the callback.
-    pub fn set_cycle_context(
+    /// Sets the cycle context for the mapping callback.
+    pub fn set_cycle_map_context(
         &mut self,
         playback_state: ContextPlaybackState,
         time_base: &BeatTimeBase,
@@ -367,6 +367,18 @@ impl LuaCallback {
         self.set_context_playback_state(playback_state)?;
         self.set_context_time_base(time_base)?;
         self.set_context_cycle_step(channel, step, step_length)?;
+        Ok(())
+    }
+
+    /// Sets the cycle context for the variables callback.
+    pub fn set_cycle_var_context(
+        &mut self,
+        parameters: ParameterSet,
+        iteration: u32,
+    ) -> LuaResult<()> {
+        self.set_context_parameters(parameters)?;
+        let values = &mut self.context.borrow_mut::<CallbackContext>()?.values;
+        values.insert(b"iteration", (iteration.wrapping_add(1)).into());
         Ok(())
     }
 

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use mlua::prelude::*;
 
-use crate::{emitter::scripted_cycle::UserMapping, event::NoteEvent, tidal::Cycle};
+use crate::{
+    bindings::LuaCallback, emitter::scripted_cycle::ScriptedCycleMapping, event::NoteEvent,
+    tidal::Cycle,
+};
 
 use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_events_from_value};
 
@@ -12,7 +15,7 @@ use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_event
 #[derive(Clone, Debug)]
 pub struct CycleUserData {
     pub cycle: Cycle,
-    pub mapping: UserMapping<Vec<Option<NoteEvent>>, LuaFunction>,
+    pub mapping: ScriptedCycleMapping<Vec<Option<NoteEvent>>>,
     pub variables_function: Option<LuaFunction>,
 }
 
@@ -26,10 +29,11 @@ impl CycleUserData {
             cycle = cycle.with_seed(seed);
         }
 
+        let mapping = ScriptedCycleMapping::default();
         let variables_function = None;
         Ok(CycleUserData {
             cycle,
-            mapping: UserMapping::Table(HashMap::new()),
+            mapping,
             variables_function,
         })
     }
@@ -37,9 +41,9 @@ impl CycleUserData {
 
 impl LuaUserData for CycleUserData {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
-        methods.add_method_mut("map", |_lua, this, value: LuaValue| match value {
+        methods.add_method_mut("map", |lua, this, value: LuaValue| match value {
             LuaValue::Function(func) => Ok(Self {
-                mapping: UserMapping::Function(func),
+                mapping: ScriptedCycleMapping::Function(LuaCallback::new(lua, func)?),
                 ..this.clone()
             }),
             LuaValue::Table(table) => {
@@ -48,7 +52,7 @@ impl LuaUserData for CycleUserData {
                     mappings.insert(k.to_string()?, note_events_from_value(&v, None)?);
                 }
                 Ok(Self {
-                    mapping: UserMapping::Table(mappings),
+                    mapping: ScriptedCycleMapping::Table(mappings),
                     ..this.clone()
                 })
             }
@@ -95,8 +99,6 @@ impl LuaUserData for CycleUserData {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use super::*;
 
     use crate::{
@@ -107,15 +109,6 @@ mod test {
     };
 
     use pretty_assertions::assert_eq;
-
-    impl<V: Clone, F: Clone> UserMapping<V, F> {
-        fn as_vec(&self) -> Vec<(String, V)> {
-            match self.clone() {
-                Self::Table(map) => map.iter().map(|(s, v)| (s.clone(), v.clone())).collect(),
-                Self::Function(_) => vec![],
-            }
-        }
-    }
 
     fn new_test_engine() -> LuaResult<(Lua, LuaTimeoutHook)> {
         new_test_engine_with_timebase(&BeatTimeBase {
@@ -201,7 +194,7 @@ mod test {
             let variables_callback =
                 LuaCallback::new(&lua, mapped_cycle.variables_function.unwrap().clone())?;
             let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle)
-                .with_variables_callback(variables_callback, &timeout_hook)?;
+                .with_variable_callback(variables_callback, &timeout_hook, &time_base)?;
             assert_eq!(
                 event_iter
                     .run(RhythmEvent::default(), true)
@@ -229,17 +222,17 @@ mod test {
             r#"cycle("a b c"):map({a = "c0", b = 48, c = { key = "c6" }})"#,
         )?;
         assert_eq!(
-            mapped_cycle.mapping,
-            UserMapping::Table(HashMap::from([
+            mapped_cycle.mapping.map(),
+            HashMap::from([
                 ("a".to_string(), vec![new_note(Note::C0)]),
                 ("b".to_string(), vec![new_note(Note::C4)]),
                 ("c".to_string(), vec![new_note(Note::C6)]),
-            ]))
+            ])
         );
 
         // check if mappings are applied correctly
-        let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
+        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
+            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -253,8 +246,8 @@ mod test {
 
         // check note properties
         let mapped_cycle = evaluate_cycle_userdata(&lua, r#"cycle("a:1:g0.1:v0.1:p-1.0:d0.3")"#)?;
-        let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
+        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
+            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -274,8 +267,8 @@ mod test {
             &lua,
             r#"cycle("a:1 a:2 a"):map({ a = { key = 48, instrument = 66 } })"#,
         )?;
-        let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
+        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
+            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -292,8 +285,8 @@ mod test {
             &lua,
             r#"cycle("a:1:v.1 a"):map({ a = { key = 48, instrument = 66, volume = 1.0 } })"#,
         )?;
-        let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
+        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
+            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -336,15 +329,8 @@ mod test {
                     end
                 end)"#,
         )?;
-        let mapping_callback = LuaCallback::new(
-            &lua,
-            match mapped_cycle.mapping {
-                UserMapping::Table(_) => panic!("lua function for mapping was defined"),
-                UserMapping::Function(f) => f.clone(),
-            },
-        )?;
         let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle).with_mapping_callback(
-            mapping_callback,
+            mapped_cycle.mapping.callback().unwrap().clone(),
             &timeout_hook,
             &time_base,
         )?;

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -1,6 +1,6 @@
 use mlua::prelude::*;
 
-use crate::{event::NoteEvent, tidal::Cycle};
+use crate::{bindings::unwrap::assign_cycle_vars_from_table, event::NoteEvent, tidal::Cycle};
 
 use super::unwrap::{bad_argument_error, note_events_from_value};
 
@@ -12,6 +12,7 @@ pub struct CycleUserData {
     pub cycle: Cycle,
     pub mappings: Vec<(String, Vec<Option<NoteEvent>>)>,
     pub mapping_function: Option<LuaFunction>,
+    pub variables_function: Option<LuaFunction>,
 }
 
 impl CycleUserData {
@@ -26,10 +27,12 @@ impl CycleUserData {
 
         let mappings = Vec::new();
         let mapping_function = None;
+        let variables_function = None;
         Ok(CycleUserData {
             cycle,
             mappings,
             mapping_function,
+            variables_function,
         })
     }
 }
@@ -37,27 +40,45 @@ impl CycleUserData {
 impl LuaUserData for CycleUserData {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         methods.add_method_mut("map", |_lua, this, value: LuaValue| match value {
-            LuaValue::Function(func) => {
-                let cycle = this.cycle.clone();
-                let mappings = Vec::new();
-                let mapping_function = Some(func);
-                Ok(CycleUserData {
-                    cycle,
-                    mappings,
-                    mapping_function,
-                })
-            }
+            LuaValue::Function(func) => Ok(Self {
+                mapping_function: Some(func),
+                mappings: Vec::new(),
+                ..this.clone()
+            }),
             LuaValue::Table(table) => {
-                let cycle = this.cycle.clone();
                 let mut mappings = Vec::new();
                 for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
                     mappings.push((k.to_string()?, note_events_from_value(&v, None)?));
                 }
-                let mapping_function = None;
-                Ok(CycleUserData {
-                    cycle,
+                Ok(Self {
+                    mapping_function: None,
                     mappings,
-                    mapping_function,
+                    ..this.clone()
+                })
+            }
+            _ => Err(bad_argument_error(
+                None,
+                "map",
+                1,
+                format!(
+                    "map argument must be a table but is a '{}'",
+                    value.type_name()
+                )
+                .as_str(),
+            )),
+        });
+
+        methods.add_method_mut("var", |_lua, this, value: LuaValue| match value {
+            LuaValue::Table(table) => {
+                let mut cloned = this.clone();
+                assign_cycle_vars_from_table(&mut cloned.cycle, table)?;
+                Ok(cloned)
+            }
+            LuaValue::Function(func) => {
+                this.cycle.clear_vars();
+                Ok(Self {
+                    variables_function: Some(func),
+                    ..this.clone()
                 })
             }
             _ => Err(bad_argument_error(
@@ -86,7 +107,7 @@ mod test {
         bindings::*,
         emitter::{cycle::CycleEmitter, scripted_cycle::ScriptedCycleEmitter},
         event::new_note,
-        Emitter, Event, Note, RhythmEvent,
+        CycleSubCycle, Emitter, Event, Note, RhythmEvent,
     };
 
     use pretty_assertions::assert_eq;
@@ -121,6 +142,31 @@ mod test {
         let (lua, _) = new_test_engine()?;
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[<")"#).is_err());
         assert!(evaluate_cycle_userdata(&lua, r#"cycle("[c4 e6]")"#).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn variables() -> LuaResult<()> {
+        let (lua, _) = new_test_engine()?;
+
+        let mapped_cycle = evaluate_cycle_userdata(
+            &lua,
+            r#"cycle("a b c"):var({x = "c0", y = "b4:v0.5", z = "[a b c]"})"#,
+        )?;
+
+        assert_eq!(
+            mapped_cycle.cycle.get_var("x").expect("x should exist"),
+            CycleSubCycle::from("c0").expect("valid subcycle")
+        );
+
+        assert_eq!(
+            mapped_cycle.cycle.get_var("y").expect("y should exist"),
+            CycleSubCycle::from("b4:v0.5").expect("valid subcycle")
+        );
+
+        assert!(mapped_cycle.cycle.get_var("a").is_none());
+        assert!(mapped_cycle.cycle.get_var("z").is_some());
 
         Ok(())
     }
@@ -249,6 +295,7 @@ mod test {
             LuaCallback::new(&lua, mapped_cycle.mapping_function.unwrap().clone())?;
         let mut event_iter = ScriptedCycleEmitter::with_mapping_callback(
             mapped_cycle.cycle,
+            None,
             &timeout_hook,
             mapping_callback,
             &time_base,

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -1,8 +1,8 @@
 use mlua::prelude::*;
 
-use crate::{bindings::unwrap::assign_cycle_vars_from_table, event::NoteEvent, tidal::Cycle};
+use crate::{event::NoteEvent, tidal::Cycle};
 
-use super::unwrap::{bad_argument_error, note_events_from_value};
+use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_events_from_value};
 
 // ---------------------------------------------------------------------------------------------
 
@@ -83,10 +83,10 @@ impl LuaUserData for CycleUserData {
             }
             _ => Err(bad_argument_error(
                 None,
-                "map",
+                "var",
                 1,
                 format!(
-                    "map argument must be a table but is a '{}'",
+                    "var argument must be a table or a function but is a '{}'",
                     value.type_name()
                 )
                 .as_str(),

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use mlua::prelude::*;
 
 use crate::{
-    bindings::LuaCallback, emitter::scripted_cycle::ScriptedCycleMapping, event::NoteEvent,
-    tidal::Cycle,
+    bindings::LuaCallback, emitter::scripted_cycle::ScriptedCycleMapping, event::NoteEvent, Cycle,
+    CycleSubCycle,
 };
 
-use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_events_from_value};
+use super::unwrap::{bad_argument_error, note_events_from_value, subcycle_values_from_table};
 
 // ---------------------------------------------------------------------------------------------
 
@@ -15,8 +15,8 @@ use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_event
 #[derive(Clone, Debug)]
 pub struct CycleUserData {
     pub cycle: Cycle,
-    pub mapping: ScriptedCycleMapping<Vec<Option<NoteEvent>>>,
-    pub variables_function: Option<LuaFunction>,
+    pub mappings: ScriptedCycleMapping<Vec<Option<NoteEvent>>>,
+    pub variables: ScriptedCycleMapping<CycleSubCycle>,
 }
 
 impl CycleUserData {
@@ -28,13 +28,12 @@ impl CycleUserData {
         if let Some(seed) = seed {
             cycle = cycle.with_seed(seed);
         }
-
         let mapping = ScriptedCycleMapping::default();
-        let variables_function = None;
+        let variables = ScriptedCycleMapping::default();
         Ok(CycleUserData {
             cycle,
-            mapping,
-            variables_function,
+            mappings: mapping,
+            variables,
         })
     }
 }
@@ -43,16 +42,16 @@ impl LuaUserData for CycleUserData {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         methods.add_method_mut("map", |lua, this, value: LuaValue| match value {
             LuaValue::Function(func) => Ok(Self {
-                mapping: ScriptedCycleMapping::Function(LuaCallback::new(lua, func)?),
+                mappings: ScriptedCycleMapping::Function(LuaCallback::new(lua, func)?),
                 ..this.clone()
             }),
             LuaValue::Table(table) => {
-                let mut mappings = HashMap::new();
+                let mut mappings = HashMap::with_capacity(table.raw_len());
                 for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
                     mappings.insert(k.to_string()?, note_events_from_value(&v, None)?);
                 }
                 Ok(Self {
-                    mapping: ScriptedCycleMapping::Table(mappings),
+                    mappings: ScriptedCycleMapping::Table(mappings),
                     ..this.clone()
                 })
             }
@@ -68,19 +67,15 @@ impl LuaUserData for CycleUserData {
             )),
         });
 
-        methods.add_method_mut("var", |_lua, this, value: LuaValue| match value {
-            LuaValue::Table(table) => {
-                let mut cloned = this.clone();
-                assign_cycle_vars_from_table(&mut cloned.cycle, table)?;
-                Ok(cloned)
-            }
-            LuaValue::Function(func) => {
-                this.cycle.clear_vars();
-                Ok(Self {
-                    variables_function: Some(func),
-                    ..this.clone()
-                })
-            }
+        methods.add_method_mut("var", |lua, this, value: LuaValue| match value {
+            LuaValue::Table(table) => Ok(Self {
+                variables: ScriptedCycleMapping::Table(subcycle_values_from_table(table)?),
+                ..this.clone()
+            }),
+            LuaValue::Function(func) => Ok(Self {
+                variables: ScriptedCycleMapping::Function(LuaCallback::new(lua, func)?),
+                ..this.clone()
+            }),
             _ => Err(bad_argument_error(
                 None,
                 "var",
@@ -102,10 +97,8 @@ mod test {
     use super::*;
 
     use crate::{
-        bindings::*,
-        emitter::{cycle::CycleEmitter, scripted_cycle::ScriptedCycleEmitter},
-        event::new_note,
-        CycleSubCycle, Emitter, Event, Note, RhythmEvent,
+        bindings::*, emitter::scripted_cycle::ScriptedCycleEmitter, event::new_note, CycleSubCycle,
+        Emitter, Event, Note, RhythmEvent,
     };
 
     use pretty_assertions::assert_eq;
@@ -148,23 +141,25 @@ mod test {
     fn variables() -> LuaResult<()> {
         let (lua, _) = new_test_engine()?;
 
-        let mapped_cycle = evaluate_cycle_userdata(
+        let cycle_userdata = evaluate_cycle_userdata(
             &lua,
             r#"cycle("a b c"):var({x = "c0", y = "b4:v0.5", z = "[a b c]"})"#,
         )?;
+        let variables_table = match &cycle_userdata.variables {
+            ScriptedCycleMapping::Table(map) => map,
+            ScriptedCycleMapping::Function(_) => panic!("Expected a variables table here"),
+        };
 
+        assert!(!variables_table.contains_key("a"));
         assert_eq!(
-            mapped_cycle.cycle.get_var("x").expect("x should exist"),
+            variables_table["x"],
             CycleSubCycle::from("c0").expect("valid subcycle")
         );
-
         assert_eq!(
-            mapped_cycle.cycle.get_var("y").expect("y should exist"),
+            variables_table["y"],
             CycleSubCycle::from("b4:v0.5").expect("valid subcycle")
         );
-
-        assert!(mapped_cycle.cycle.get_var("a").is_none());
-        assert!(mapped_cycle.cycle.get_var("z").is_some());
+        assert!(variables_table.contains_key("z"));
 
         Ok(())
     }
@@ -179,10 +174,9 @@ mod test {
 
         let (lua, timeout_hook) = new_test_engine_with_timebase(&time_base)?;
 
-        {
-            let mapped_cycle = evaluate_cycle_userdata(
-                &lua,
-                r#"
+        let cycle_userdata = evaluate_cycle_userdata(
+            &lua,
+            r#"
                 cycle("a b c $x $y $z"):var(function(context)
                     return {
                         x = "d" .. context.iteration,
@@ -190,25 +184,27 @@ mod test {
                         z = "f",
                     }
                 end)"#,
-            )?;
-            let variables_callback =
-                LuaCallback::new(&lua, mapped_cycle.variables_function.unwrap().clone())?;
-            let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle)
-                .with_variable_callback(variables_callback, &timeout_hook, &time_base)?;
-            assert_eq!(
-                event_iter
-                    .run(RhythmEvent::default(), true)
-                    .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
-                Some(vec![
-                    Event::NoteEvents(vec![new_note(Note::A4)]),
-                    Event::NoteEvents(vec![new_note(Note::B4)]),
-                    Event::NoteEvents(vec![new_note(Note::C4)]),
-                    Event::NoteEvents(vec![new_note(Note::D1)]),
-                    Event::NoteEvents(vec![new_note(Note::E4)]),
-                    Event::NoteEvents(vec![new_note(Note::F4)]),
-                ])
-            );
-        }
+        )?;
+        let variables_callback = match &cycle_userdata.variables {
+            ScriptedCycleMapping::Function(f) => f.clone(),
+            ScriptedCycleMapping::Table(_) => panic!("Expected a variables callback here"),
+        };
+
+        let mut event_iter = ScriptedCycleEmitter::new(cycle_userdata.cycle)
+            .with_variables_callback(variables_callback, &timeout_hook, &time_base)?;
+        assert_eq!(
+            event_iter
+                .run(RhythmEvent::default(), true)
+                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+            Some(vec![
+                Event::NoteEvents(vec![new_note(Note::A4)]),
+                Event::NoteEvents(vec![new_note(Note::B4)]),
+                Event::NoteEvents(vec![new_note(Note::C4)]),
+                Event::NoteEvents(vec![new_note(Note::D1)]),
+                Event::NoteEvents(vec![new_note(Note::E4)]),
+                Event::NoteEvents(vec![new_note(Note::F4)]),
+            ])
+        );
 
         Ok(())
     }
@@ -217,12 +213,16 @@ mod test {
     fn mappings() -> LuaResult<()> {
         let (lua, _) = new_test_engine()?;
 
-        let mapped_cycle = evaluate_cycle_userdata(
+        let cycle_userdata = evaluate_cycle_userdata(
             &lua,
             r#"cycle("a b c"):map({a = "c0", b = 48, c = { key = "c6" }})"#,
         )?;
+        let mappings_table = match &cycle_userdata.mappings {
+            ScriptedCycleMapping::Table(map) => map.clone(),
+            ScriptedCycleMapping::Function(_) => panic!("Expected a mapping table to be set here"),
+        };
         assert_eq!(
-            mapped_cycle.mapping.map(),
+            mappings_table,
             HashMap::from([
                 ("a".to_string(), vec![new_note(Note::C0)]),
                 ("b".to_string(), vec![new_note(Note::C4)]),
@@ -231,8 +231,8 @@ mod test {
         );
 
         // check if mappings are applied correctly
-        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
-            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
+        let mut event_iter =
+            ScriptedCycleEmitter::new(cycle_userdata.cycle).with_mappings(mappings_table);
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -244,31 +244,20 @@ mod test {
             ])
         );
 
-        // check note properties
-        let mapped_cycle = evaluate_cycle_userdata(&lua, r#"cycle("a:1:g0.1:v0.1:p-1.0:d0.3")"#)?;
-        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
-            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
-        assert_eq!(
-            event_iter
-                .run(RhythmEvent::default(), true)
-                .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
-            Some(vec![Event::NoteEvents(vec![new_note((
-                Note::A4,
-                InstrumentId::from(1),
-                Some(0.1),
-                0.1,
-                -1.0,
-                0.3,
-            ))]),])
-        );
-
         // check instrument overrides
-        let mapped_cycle = evaluate_cycle_userdata(
+        let cycle_userdata = evaluate_cycle_userdata(
             &lua,
             r#"cycle("a:1 a:2 a"):map({ a = { key = 48, instrument = 66 } })"#,
         )?;
-        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
-            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
+        let mappings_table = match &cycle_userdata.mappings {
+            ScriptedCycleMapping::Table(map) => map.clone(),
+            ScriptedCycleMapping::Function(_) => {
+                panic!("Expected a mapping table to be set here")
+            }
+        };
+
+        let mut event_iter =
+            ScriptedCycleEmitter::new(cycle_userdata.cycle).with_mappings(mappings_table);
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -281,12 +270,19 @@ mod test {
         );
 
         // check note property overrides
-        let mapped_cycle = evaluate_cycle_userdata(
+        let cycle_userdata = evaluate_cycle_userdata(
             &lua,
             r#"cycle("a:1:v.1 a"):map({ a = { key = 48, instrument = 66, volume = 1.0 } })"#,
         )?;
-        let mut event_iter = CycleEmitter::new(mapped_cycle.cycle)
-            .with_mappings(&mapped_cycle.mapping.map().into_iter().collect::<Vec<_>>());
+        let mappings_table = match &cycle_userdata.mappings {
+            ScriptedCycleMapping::Table(map) => map.clone(),
+            ScriptedCycleMapping::Function(_) => {
+                panic!("Expected a mapping table to be set here")
+            }
+        };
+
+        let mut event_iter =
+            ScriptedCycleEmitter::new(cycle_userdata.cycle).with_mappings(mappings_table);
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -315,7 +311,7 @@ mod test {
 
         let (lua, timeout_hook) = new_test_engine_with_timebase(&time_base)?;
 
-        let mapped_cycle = evaluate_cycle_userdata(
+        let cycle_userdata = evaluate_cycle_userdata(
             &lua,
             r#"
                 cycle("wurst a b c"):map(function(context, value)
@@ -329,11 +325,13 @@ mod test {
                     end
                 end)"#,
         )?;
-        let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle).with_mapping_callback(
-            mapped_cycle.mapping.callback().unwrap().clone(),
-            &timeout_hook,
-            &time_base,
-        )?;
+        let mappings_callback = match &cycle_userdata.mappings {
+            ScriptedCycleMapping::Function(f) => f.clone(),
+            ScriptedCycleMapping::Table(_) => panic!("Expected a mapping callback to be set here"),
+        };
+
+        let mut event_iter = ScriptedCycleEmitter::new(cycle_userdata.cycle)
+            .with_mapping_callback(mappings_callback, &timeout_hook, &time_base)?;
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)

--- a/src/bindings/cycle.rs
+++ b/src/bindings/cycle.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use mlua::prelude::*;
 
-use crate::{event::NoteEvent, tidal::Cycle};
+use crate::{emitter::scripted_cycle::UserMapping, event::NoteEvent, tidal::Cycle};
 
 use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_events_from_value};
 
@@ -10,8 +12,7 @@ use super::unwrap::{assign_cycle_vars_from_table, bad_argument_error, note_event
 #[derive(Clone, Debug)]
 pub struct CycleUserData {
     pub cycle: Cycle,
-    pub mappings: Vec<(String, Vec<Option<NoteEvent>>)>,
-    pub mapping_function: Option<LuaFunction>,
+    pub mapping: UserMapping<Vec<Option<NoteEvent>>, LuaFunction>,
     pub variables_function: Option<LuaFunction>,
 }
 
@@ -25,13 +26,10 @@ impl CycleUserData {
             cycle = cycle.with_seed(seed);
         }
 
-        let mappings = Vec::new();
-        let mapping_function = None;
         let variables_function = None;
         Ok(CycleUserData {
             cycle,
-            mappings,
-            mapping_function,
+            mapping: UserMapping::Table(HashMap::new()),
             variables_function,
         })
     }
@@ -41,18 +39,16 @@ impl LuaUserData for CycleUserData {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         methods.add_method_mut("map", |_lua, this, value: LuaValue| match value {
             LuaValue::Function(func) => Ok(Self {
-                mapping_function: Some(func),
-                mappings: Vec::new(),
+                mapping: UserMapping::Function(func),
                 ..this.clone()
             }),
             LuaValue::Table(table) => {
-                let mut mappings = Vec::new();
+                let mut mappings = HashMap::new();
                 for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
-                    mappings.push((k.to_string()?, note_events_from_value(&v, None)?));
+                    mappings.insert(k.to_string()?, note_events_from_value(&v, None)?);
                 }
                 Ok(Self {
-                    mapping_function: None,
-                    mappings,
+                    mapping: UserMapping::Table(mappings),
                     ..this.clone()
                 })
             }
@@ -111,6 +107,15 @@ mod test {
     };
 
     use pretty_assertions::assert_eq;
+
+    impl<V: Clone, F: Clone> UserMapping<V, F> {
+        fn as_vec(&self) -> Vec<(String, V)> {
+            match self.clone() {
+                Self::Table(map) => map.iter().map(|(s, v)| (s.clone(), v.clone())).collect(),
+                Self::Function(_) => vec![],
+            }
+        }
+    }
 
     fn new_test_engine() -> LuaResult<(Lua, LuaTimeoutHook)> {
         new_test_engine_with_timebase(&BeatTimeBase {
@@ -172,6 +177,50 @@ mod test {
     }
 
     #[test]
+    fn variables_function() -> LuaResult<()> {
+        let time_base = BeatTimeBase {
+            beats_per_min: 120.0,
+            beats_per_bar: 4,
+            samples_per_sec: 44100,
+        };
+
+        let (lua, timeout_hook) = new_test_engine_with_timebase(&time_base)?;
+
+        {
+            let mapped_cycle = evaluate_cycle_userdata(
+                &lua,
+                r#"
+                cycle("a b c $x $y $z"):var(function(context)
+                    return {
+                        x = "d" .. context.iteration,
+                        y = "e",
+                        z = "f",
+                    }
+                end)"#,
+            )?;
+            let variables_callback =
+                LuaCallback::new(&lua, mapped_cycle.variables_function.unwrap().clone())?;
+            let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle)
+                .with_variables_callback(variables_callback, &timeout_hook)?;
+            assert_eq!(
+                event_iter
+                    .run(RhythmEvent::default(), true)
+                    .map(|events| events.into_iter().map(|e| e.event).collect::<Vec<_>>()),
+                Some(vec![
+                    Event::NoteEvents(vec![new_note(Note::A4)]),
+                    Event::NoteEvents(vec![new_note(Note::B4)]),
+                    Event::NoteEvents(vec![new_note(Note::C4)]),
+                    Event::NoteEvents(vec![new_note(Note::D1)]),
+                    Event::NoteEvents(vec![new_note(Note::E4)]),
+                    Event::NoteEvents(vec![new_note(Note::F4)]),
+                ])
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
     fn mappings() -> LuaResult<()> {
         let (lua, _) = new_test_engine()?;
 
@@ -180,21 +229,17 @@ mod test {
             r#"cycle("a b c"):map({a = "c0", b = 48, c = { key = "c6" }})"#,
         )?;
         assert_eq!(
-            mapped_cycle
-                .mappings
-                .clone()
-                .into_iter()
-                .collect::<HashMap<_, _>>(),
-            HashMap::from([
+            mapped_cycle.mapping,
+            UserMapping::Table(HashMap::from([
                 ("a".to_string(), vec![new_note(Note::C0)]),
                 ("b".to_string(), vec![new_note(Note::C4)]),
                 ("c".to_string(), vec![new_note(Note::C6)]),
-            ])
+            ]))
         );
 
         // check if mappings are applied correctly
         let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -209,7 +254,7 @@ mod test {
         // check note properties
         let mapped_cycle = evaluate_cycle_userdata(&lua, r#"cycle("a:1:g0.1:v0.1:p-1.0:d0.3")"#)?;
         let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -230,7 +275,7 @@ mod test {
             r#"cycle("a:1 a:2 a"):map({ a = { key = 48, instrument = 66 } })"#,
         )?;
         let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -248,7 +293,7 @@ mod test {
             r#"cycle("a:1:v.1 a"):map({ a = { key = 48, instrument = 66, volume = 1.0 } })"#,
         )?;
         let mut event_iter =
-            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mappings);
+            CycleEmitter::new(mapped_cycle.cycle).with_mappings(&mapped_cycle.mapping.as_vec());
         assert_eq!(
             event_iter
                 .run(RhythmEvent::default(), true)
@@ -291,13 +336,16 @@ mod test {
                     end
                 end)"#,
         )?;
-        let mapping_callback =
-            LuaCallback::new(&lua, mapped_cycle.mapping_function.unwrap().clone())?;
-        let mut event_iter = ScriptedCycleEmitter::with_mapping_callback(
-            mapped_cycle.cycle,
-            None,
-            &timeout_hook,
+        let mapping_callback = LuaCallback::new(
+            &lua,
+            match mapped_cycle.mapping {
+                UserMapping::Table(_) => panic!("lua function for mapping was defined"),
+                UserMapping::Function(f) => f.clone(),
+            },
+        )?;
+        let mut event_iter = ScriptedCycleEmitter::new(mapped_cycle.cycle).with_mapping_callback(
             mapping_callback,
+            &timeout_hook,
             &time_base,
         )?;
         assert_eq!(

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -10,6 +10,7 @@ use crate::{
         parameter::ParameterUserData, sequence::SequenceUserData, LuaTimeoutHook,
     },
     prelude::*,
+    CycleSubCycle,
 };
 
 // ---------------------------------------------------------------------------------------------
@@ -1031,6 +1032,45 @@ pub(crate) fn gate_from_value(
 
 // -------------------------------------------------------------------------------------------------
 
+fn cycle_to_lua_error(arg: &LuaValue, string: String) -> LuaError {
+    LuaError::FromLuaConversionError {
+        from: arg.type_name(),
+        to: "cycle variable".to_string(),
+        message: Some(string),
+    }
+}
+
+fn subcycle_from_value(arg: &LuaValue) -> LuaResult<CycleSubCycle> {
+    let subcycle_result = match arg {
+        LuaValue::Integer(x) => {
+            Ok(CycleSubCycle::integer((*x).try_into().map_err(|err| {
+                cycle_to_lua_error(arg, format!("{err}"))
+            })?))
+        }
+        LuaValue::Number(x) => Ok(CycleSubCycle::float(*x)),
+        LuaValue::String(x) => CycleSubCycle::from(&x.to_str()?),
+        LuaValue::Boolean(x) => Ok(CycleSubCycle::integer(if *x { 1 } else { 0 })),
+        LuaValue::Nil => Ok(CycleSubCycle::rest()),
+        // TODO convert from note table presentation to cycle note?
+        _ => {
+            return Err(LuaError::FromLuaConversionError {
+                from: arg.type_name(),
+                to: "cycle variable".to_string(),
+                message: Some("type couldn't be converted to a sub cycle".to_string()),
+            })
+        }
+    };
+
+    subcycle_result.map_err(|err| cycle_to_lua_error(arg, err))
+}
+
+pub(crate) fn assign_cycle_vars_from_table(cycle: &mut Cycle, table: LuaTable) -> LuaResult<()> {
+    for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
+        cycle.set_var(&k.to_string()?, subcycle_from_value(&v)?)
+    }
+    Ok(())
+}
+
 pub(crate) fn emitter_from_value(
     lua: &Lua,
     timeout_hook: &LuaTimeoutHook,
@@ -1049,10 +1089,16 @@ pub(crate) fn emitter_from_value(
                 // NB: take instead of cloning: cycle userdata has no other usage than being defined
                 let userdata = userdata.take::<CycleUserData>()?;
                 let cycle = userdata.cycle;
+                let variables_callback = if let Some(func) = userdata.variables_function {
+                    Some(LuaCallback::new(lua, func)?)
+                } else {
+                    None
+                };
                 if let Some(mapping_function) = userdata.mapping_function {
                     let mapping_callback = LuaCallback::new(lua, mapping_function)?;
                     let emitter = ScriptedCycleEmitter::with_mapping_callback(
                         cycle,
+                        variables_callback,
                         timeout_hook,
                         mapping_callback,
                         time_base,
@@ -1060,7 +1106,8 @@ pub(crate) fn emitter_from_value(
                     Ok(Box::new(emitter))
                 } else {
                     let mappings = userdata.mappings;
-                    let emitter = ScriptedCycleEmitter::with_mappings(cycle, mappings);
+                    let emitter =
+                        ScriptedCycleEmitter::with_mappings(cycle, variables_callback, mappings);
                     Ok(Box::new(emitter))
                 }
             } else {

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -9,7 +9,7 @@ use crate::{
         callback::LuaCallback, cycle::CycleUserData, note::NoteUserData,
         parameter::ParameterUserData, sequence::SequenceUserData, LuaTimeoutHook,
     },
-    emitter::scripted_cycle::UserMapping,
+    emitter::scripted_cycle::ScriptedCycleMapping,
     prelude::*,
     CycleSubCycle,
 };
@@ -1033,15 +1033,15 @@ pub(crate) fn gate_from_value(
 
 // -------------------------------------------------------------------------------------------------
 
-fn cycle_to_lua_error(arg: &LuaValue, string: String) -> LuaError {
-    LuaError::FromLuaConversionError {
-        from: arg.type_name(),
-        to: "cycle variable".to_string(),
-        message: Some(string),
-    }
-}
-
 fn subcycle_from_value(arg: &LuaValue) -> LuaResult<CycleSubCycle> {
+    fn cycle_to_lua_error(arg: &LuaValue, string: String) -> LuaError {
+        LuaError::FromLuaConversionError {
+            from: arg.type_name(),
+            to: "cycle variable".to_string(),
+            message: Some(string),
+        }
+    }
+
     let subcycle_result = match arg {
         LuaValue::Integer(x) => {
             Ok(CycleSubCycle::integer((*x).try_into().map_err(|err| {
@@ -1090,21 +1090,22 @@ pub(crate) fn emitter_from_value(
                 // NB: take instead of cloning: cycle userdata has no other usage than being defined
                 let userdata = userdata.take::<CycleUserData>()?;
                 let cycle = userdata.cycle;
-
+                // with variables
                 let emitter = if let Some(func) = userdata.variables_function {
-                    ScriptedCycleEmitter::new(cycle.clone())
-                        .with_variables_callback(LuaCallback::new(lua, func)?, timeout_hook)?
-                } else {
-                    ScriptedCycleEmitter::new(cycle.clone())
-                };
-
-                let emitter = match userdata.mapping {
-                    UserMapping::Table(hash_map) => emitter.with_mappings(hash_map),
-                    UserMapping::Function(func) => emitter.with_mapping_callback(
+                    ScriptedCycleEmitter::new(cycle.clone()).with_variable_callback(
                         LuaCallback::new(lua, func)?,
                         timeout_hook,
                         time_base,
-                    )?,
+                    )?
+                } else {
+                    ScriptedCycleEmitter::new(cycle.clone())
+                };
+                // with mappings
+                let emitter = match userdata.mapping {
+                    ScriptedCycleMapping::Table(map) => emitter.with_mappings(map),
+                    ScriptedCycleMapping::Function(callback) => {
+                        emitter.with_mapping_callback(callback, timeout_hook, time_base)?
+                    }
                 };
                 Ok(Box::new(emitter))
             } else {

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -1,6 +1,6 @@
 //! Various lua->rust conversion helpers
 
-use std::{cell::RefCell, ops::RangeBounds, rc::Rc, sync::Arc};
+use std::{cell::RefCell, collections::HashMap, ops::RangeBounds, rc::Rc, sync::Arc};
 
 use mlua::prelude::*;
 
@@ -1065,12 +1065,17 @@ fn subcycle_from_value(arg: &LuaValue) -> LuaResult<CycleSubCycle> {
     subcycle_result.map_err(|err| cycle_to_lua_error(arg, err))
 }
 
-pub(crate) fn assign_cycle_vars_from_table(cycle: &mut Cycle, table: LuaTable) -> LuaResult<()> {
+pub(crate) fn subcycle_values_from_table(
+    table: LuaTable,
+) -> LuaResult<HashMap<String, CycleSubCycle>> {
+    let mut map = HashMap::with_capacity(table.raw_len());
     for (k, v) in table.pairs::<LuaValue, LuaValue>().flatten() {
-        cycle.set_var(&k.to_string()?, subcycle_from_value(&v)?)
+        map.insert(k.to_string()?, subcycle_from_value(&v)?);
     }
-    Ok(())
+    Ok(map)
 }
+
+// -------------------------------------------------------------------------------------------------
 
 pub(crate) fn emitter_from_value(
     lua: &Lua,
@@ -1089,19 +1094,16 @@ pub(crate) fn emitter_from_value(
             } else if userdata.is::<CycleUserData>() {
                 // NB: take instead of cloning: cycle userdata has no other usage than being defined
                 let userdata = userdata.take::<CycleUserData>()?;
-                let cycle = userdata.cycle;
-                // with variables
-                let emitter = if let Some(func) = userdata.variables_function {
-                    ScriptedCycleEmitter::new(cycle.clone()).with_variable_callback(
-                        LuaCallback::new(lua, func)?,
-                        timeout_hook,
-                        time_base,
-                    )?
-                } else {
-                    ScriptedCycleEmitter::new(cycle.clone())
-                };
-                // with mappings
-                let emitter = match userdata.mapping {
+                let emitter = ScriptedCycleEmitter::new(userdata.cycle);
+                // apply variables
+                let emitter =
+                    match userdata.variables {
+                        ScriptedCycleMapping::Table(map) => emitter.with_variables(map),
+                        ScriptedCycleMapping::Function(callback) => emitter
+                            .with_variables_callback(callback.clone(), timeout_hook, time_base)?,
+                    };
+                // apply mappings
+                let emitter = match userdata.mappings {
                     ScriptedCycleMapping::Table(map) => emitter.with_mappings(map),
                     ScriptedCycleMapping::Function(callback) => {
                         emitter.with_mapping_callback(callback, timeout_hook, time_base)?

--- a/src/bindings/unwrap.rs
+++ b/src/bindings/unwrap.rs
@@ -9,6 +9,7 @@ use crate::{
         callback::LuaCallback, cycle::CycleUserData, note::NoteUserData,
         parameter::ParameterUserData, sequence::SequenceUserData, LuaTimeoutHook,
     },
+    emitter::scripted_cycle::UserMapping,
     prelude::*,
     CycleSubCycle,
 };
@@ -1089,27 +1090,23 @@ pub(crate) fn emitter_from_value(
                 // NB: take instead of cloning: cycle userdata has no other usage than being defined
                 let userdata = userdata.take::<CycleUserData>()?;
                 let cycle = userdata.cycle;
-                let variables_callback = if let Some(func) = userdata.variables_function {
-                    Some(LuaCallback::new(lua, func)?)
+
+                let emitter = if let Some(func) = userdata.variables_function {
+                    ScriptedCycleEmitter::new(cycle.clone())
+                        .with_variables_callback(LuaCallback::new(lua, func)?, timeout_hook)?
                 } else {
-                    None
+                    ScriptedCycleEmitter::new(cycle.clone())
                 };
-                if let Some(mapping_function) = userdata.mapping_function {
-                    let mapping_callback = LuaCallback::new(lua, mapping_function)?;
-                    let emitter = ScriptedCycleEmitter::with_mapping_callback(
-                        cycle,
-                        variables_callback,
+
+                let emitter = match userdata.mapping {
+                    UserMapping::Table(hash_map) => emitter.with_mappings(hash_map),
+                    UserMapping::Function(func) => emitter.with_mapping_callback(
+                        LuaCallback::new(lua, func)?,
                         timeout_hook,
-                        mapping_callback,
                         time_base,
-                    )?;
-                    Ok(Box::new(emitter))
-                } else {
-                    let mappings = userdata.mappings;
-                    let emitter =
-                        ScriptedCycleEmitter::with_mappings(cycle, variables_callback, mappings);
-                    Ok(Box::new(emitter))
-                }
+                    )?,
+                };
+                Ok(Box::new(emitter))
             } else {
                 Err(LuaError::FromLuaConversionError {
                     from: "userdata",

--- a/src/emitter/scripted.rs
+++ b/src/emitter/scripted.rs
@@ -129,7 +129,7 @@ impl Emitter for ScriptedEmitter {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(parameters) {
+        if let Err(err) = self.callback.set_context_parameters(&parameters) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -19,6 +19,12 @@ use crate::{
 
 // -------------------------------------------------------------------------------------------------
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum UserMapping<V: Clone, F: Clone> {
+    Table(HashMap<String, V>),
+    Function(F),
+}
+
 /// Emits a vector of [`EmitterEvent`]s from a [`Cycle`].
 ///
 /// Channels from cycle are merged down into note events on different voices.
@@ -30,56 +36,64 @@ use crate::{
 pub struct ScriptedCycleEmitter {
     cycle: Cycle,
     parameters: Vec<(Rc<RefCell<Parameter>>, Vec<CycleSubCycle>)>,
-    mappings: HashMap<String, Vec<Option<NoteEvent>>>,
-    mapping_callback: Option<LuaCallback>,
-    variables_callback: Option<LuaCallback>,
-    timeout_hook: Option<LuaTimeoutHook>,
+    mappings: UserMapping<Vec<Option<NoteEvent>>, (LuaCallback, LuaTimeoutHook)>,
+    variables_callback: Option<(LuaCallback, LuaTimeoutHook)>,
     channel_steps: Vec<usize>,
 }
 
 impl ScriptedCycleEmitter {
-    /// Return a new cycle with the given value mappings applied.
-    pub(crate) fn with_mappings(
-        cycle: Cycle,
-        variables_callback: Option<LuaCallback>,
-        mappings: Vec<(String, Vec<Option<NoteEvent>>)>,
-    ) -> Self {
-        let parameters = vec![];
-        let mappings = mappings.into_iter().collect();
-        let mapping_callback = None;
-        let timeout_hook = None;
-        let channel_steps = vec![];
+    pub(crate) fn new(cycle: Cycle) -> Self {
         Self {
             cycle,
-            parameters,
-            mappings,
-            mapping_callback,
-            variables_callback,
-            timeout_hook,
-            channel_steps,
+            parameters: vec![],
+            mappings: UserMapping::Table(HashMap::new()),
+            variables_callback: None,
+            channel_steps: vec![],
         }
+    }
+
+    /// Return a new cycle with the given value mappings applied.
+    pub(crate) fn with_mappings(self, mappings: HashMap<String, Vec<Option<NoteEvent>>>) -> Self {
+        let mappings = UserMapping::Table(mappings);
+        Self { mappings, ..self }
+    }
+
+    pub(crate) fn with_variables_callback(
+        self,
+        mut variables_callback: LuaCallback,
+        timeout_hook: &LuaTimeoutHook,
+    ) -> LuaResult<Self> {
+        // create a new timeout_hook instance and reset it before calling the function
+        let mut timeout_hook = timeout_hook.clone();
+        timeout_hook.reset();
+        let iteration = 0;
+        variables_callback.set_cycle_var_context(
+            self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+            iteration,
+        )?;
+        Ok(Self {
+            variables_callback: Some((variables_callback, timeout_hook)),
+            ..self
+        })
     }
 
     /// Return a new cycle with the given mapping callback applied.
     pub(crate) fn with_mapping_callback(
-        cycle: Cycle,
-        variables_callback: Option<LuaCallback>,
+        self,
+        mut mapping_callback: LuaCallback,
         timeout_hook: &LuaTimeoutHook,
-        mapping_callback: LuaCallback,
         time_base: &BeatTimeBase,
     ) -> LuaResult<Self> {
         // create a new timeout_hook instance and reset it before calling the function
         let mut timeout_hook = timeout_hook.clone();
         timeout_hook.reset();
         let parameters = vec![];
-        let mappings = HashMap::new();
         // initialize emitter context for the function
-        let mut mapping_callback = mapping_callback;
         let playback_state = ContextPlaybackState::Running;
         let channel = 0;
         let step = 0;
         let step_length = 0.0;
-        mapping_callback.set_cycle_context(
+        mapping_callback.set_cycle_map_context(
             playback_state,
             time_base,
             channel,
@@ -88,13 +102,10 @@ impl ScriptedCycleEmitter {
         )?;
         let channel_steps = vec![];
         Ok(Self {
-            cycle,
+            mappings: UserMapping::Function((mapping_callback, timeout_hook)),
             parameters,
-            mappings,
-            mapping_callback: Some(mapping_callback),
-            variables_callback,
-            timeout_hook: Some(timeout_hook),
             channel_steps,
+            ..self
         })
     }
 
@@ -107,27 +118,32 @@ impl ScriptedCycleEmitter {
         event: CycleEvent,
     ) -> LuaResult<Vec<Option<NoteEvent>>> {
         let mut note_events = {
-            if let Some(mapping_callback) = self.mapping_callback.as_mut() {
-                // update step in context
-                mapping_callback.set_context_cycle_step(
-                    channel_index,
-                    channel_step,
-                    step_length,
-                )?;
-                // call mapping function
-                let result = mapping_callback.call_with_arg(event.as_str().as_ref())?;
-                note_events_from_value(&result, None)?
-            } else if let Some(note_events) = self.mappings.get(event.as_str().as_ref()) {
-                // apply custom note mapping
-                note_events.clone()
-            } else {
-                // try converting the cycle value to a single note
-                event.value().try_into().map_err(LuaError::RuntimeError)?
+            match &mut self.mappings {
+                UserMapping::Function((mapping_callback, _timeout_hook)) => {
+                    // update step in context
+                    mapping_callback.set_context_cycle_step(
+                        channel_index,
+                        channel_step,
+                        step_length,
+                    )?;
+                    // call mapping function
+                    let result = mapping_callback.call_with_arg(event.as_str().as_ref())?;
+                    note_events_from_value(&result, None)?
+                }
+                UserMapping::Table(hash_map) => {
+                    if let Some(note_events) = hash_map.get(event.as_str().as_ref()) {
+                        // apply custom note mapping
+                        note_events.clone()
+                    } else {
+                        // try converting the cycle value to a single note
+                        event.value().try_into().map_err(LuaError::RuntimeError)?
+                    }
+                }
             }
         };
         // verify that all identifiers are mapped
         if (note_events.is_empty() || note_events.iter().all(|f| f.is_none()))
-            && self.mapping_callback.is_none()
+            && !matches!(self.mappings, UserMapping::Function((_, _)))
             && !matches!(event.value(), CycleValue::Rest | CycleValue::Hold)
         {
             return Err(LuaError::runtime(format!(
@@ -152,14 +168,12 @@ impl ScriptedCycleEmitter {
                 .set_var(parameter.id(), parameter.into_var(enum_values));
         }
 
-        if let Some(variables_callback) = &mut self.variables_callback {
-            let playback_state = ContextPlaybackState::Running;
-            if let Err(err) = variables_callback.set_context_playback_state(playback_state) {
-                variables_callback.handle_error(&err);
-            }
-            if let Err(err) = variables_callback
-                .set_context_parameters(self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect())
-            {
+        if let Some((variables_callback, timeout_hook)) = &mut self.variables_callback {
+            timeout_hook.reset();
+            if let Err(err) = variables_callback.set_cycle_var_context(
+                self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+                self.cycle.iteration(),
+            ) {
                 variables_callback.handle_error(&err);
             }
 
@@ -205,12 +219,10 @@ impl ScriptedCycleEmitter {
                 }
             }
         };
-        // reset timeout hook for mapping functions
-        if let Some(timeout_hook) = &mut self.timeout_hook {
-            timeout_hook.reset();
-        }
         // set callback playback state
-        if let Some(callback) = &mut self.mapping_callback {
+        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
+            // reset timeout hook for mapping functions
+            timeout_hook.reset();
             let playback_state = ContextPlaybackState::Running;
             if let Err(err) = callback.set_context_playback_state(playback_state) {
                 callback.handle_error(&err);
@@ -232,7 +244,7 @@ impl ScriptedCycleEmitter {
                 let step_length = length.to_f64().unwrap_or(0.0);
                 match self.cycle_to_note_event(channel_index, channel_step, step_length, event) {
                     Err(err) => {
-                        if let Some(callback) = &self.mapping_callback {
+                        if let UserMapping::Function((callback, _timeout_hook)) = &self.mappings {
                             callback.handle_error(&err)
                         } else {
                             let source = self.cycle.source().clone();
@@ -255,76 +267,77 @@ impl ScriptedCycleEmitter {
     /// Skip next batch of events from the cycle.
     /// This maintains cycle mapping callback states as well, if needed.
     fn advance(&mut self) {
-        if let Some(mapping_callback) = &mut self.mapping_callback {
-            // run the cycle event generator
-            let events = {
-                match self.cycle.generate() {
-                    Ok(events) => events,
-                    Err(err) => {
-                        mapping_callback.handle_error(&LuaError::RuntimeError(err));
-                        return;
+        match &mut self.mappings {
+            UserMapping::Function((mapping_callback, timeout_hook)) => {
+                // run the cycle event generator
+                let events = {
+                    match self.cycle.generate() {
+                        Ok(events) => events,
+                        Err(err) => {
+                            mapping_callback.handle_error(&LuaError::RuntimeError(err));
+                            return;
+                        }
                     }
-                }
-            };
-            if mapping_callback.is_stateful().unwrap_or(true) {
-                // reset timeout hooks
-                if let Some(timeout_hook) = &mut self.timeout_hook {
+                };
+                if mapping_callback.is_stateful().unwrap_or(true) {
+                    // reset timeout hooks
                     timeout_hook.reset();
-                }
-                // set playback state
-                let playback_state = ContextPlaybackState::Seeking;
-                if let Err(err) = mapping_callback.set_context_playback_state(playback_state) {
-                    mapping_callback.handle_error(&err);
-                }
-                // run stateful callbacks but ignore results
-                for (channel_index, channel_events) in events.into_iter().enumerate() {
-                    if self.channel_steps.len() <= channel_index {
-                        self.channel_steps.resize(channel_index + 1, 0);
+                    // set playback state
+                    let playback_state = ContextPlaybackState::Seeking;
+                    if let Err(err) = mapping_callback.set_context_playback_state(playback_state) {
+                        mapping_callback.handle_error(&err);
                     }
-                    for event in channel_events.into_iter() {
-                        // move step counter
-                        let channel_step = self.channel_steps[channel_index];
-                        self.channel_steps[channel_index] += 1;
-                        // update step in context
-                        let step_length = event.span().length().to_f64().unwrap_or(0.0);
-                        if let Err(err) = mapping_callback.set_context_cycle_step(
-                            channel_index,
-                            channel_step,
-                            step_length,
-                        ) {
-                            mapping_callback.handle_error(&err);
-                            return;
+                    // run stateful callbacks but ignore results
+                    for (channel_index, channel_events) in events.into_iter().enumerate() {
+                        if self.channel_steps.len() <= channel_index {
+                            self.channel_steps.resize(channel_index + 1, 0);
                         }
-                        // call mapping function
-                        if let Err(err) = mapping_callback.call_with_arg(event.as_str().as_ref()) {
-                            mapping_callback.handle_error(&err);
-                            return;
+                        for event in channel_events.into_iter() {
+                            // move step counter
+                            let channel_step = self.channel_steps[channel_index];
+                            self.channel_steps[channel_index] += 1;
+                            // update step in context
+                            let step_length = event.span().length().to_f64().unwrap_or(0.0);
+                            if let Err(err) = mapping_callback.set_context_cycle_step(
+                                channel_index,
+                                channel_step,
+                                step_length,
+                            ) {
+                                mapping_callback.handle_error(&err);
+                                return;
+                            }
+                            // call mapping function
+                            if let Err(err) =
+                                mapping_callback.call_with_arg(event.as_str().as_ref())
+                            {
+                                mapping_callback.handle_error(&err);
+                                return;
+                            }
                         }
                     }
-                }
-            } else {
-                // advance channel_steps for generated each event
-                for (channel_index, channel_events) in events.into_iter().enumerate() {
-                    if self.channel_steps.len() <= channel_index {
-                        self.channel_steps.resize(channel_index + 1, 0);
+                } else {
+                    // advance channel_steps for generated each event
+                    for (channel_index, channel_events) in events.into_iter().enumerate() {
+                        if self.channel_steps.len() <= channel_index {
+                            self.channel_steps.resize(channel_index + 1, 0);
+                        }
+                        self.channel_steps[channel_index] += channel_events.len();
                     }
-                    self.channel_steps[channel_index] += channel_events.len();
                 }
             }
-        } else {
-            // no mapping callback present: just advance the cycle
-            self.cycle.advance();
-            self.channel_steps.clear();
+            UserMapping::Table(_) => {
+                // no mapping callback present: just advance the cycle
+                self.cycle.advance();
+                self.channel_steps.clear();
+            }
         }
     }
 }
 
 impl Emitter for ScriptedCycleEmitter {
     fn set_time_base(&mut self, time_base: &BeatTimeBase) {
-        if let Some(timeout_hook) = &mut self.timeout_hook {
+        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
             timeout_hook.reset();
-        }
-        if let Some(callback) = &mut self.mapping_callback {
             if let Err(err) = callback.set_context_time_base(time_base) {
                 callback.handle_error(&err);
             }
@@ -332,10 +345,8 @@ impl Emitter for ScriptedCycleEmitter {
     }
 
     fn set_trigger_event(&mut self, event: &Event) {
-        if let Some(timeout_hook) = &mut self.timeout_hook {
+        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
             timeout_hook.reset();
-        }
-        if let Some(callback) = &mut self.mapping_callback {
             if let Err(err) = callback.set_context_trigger_event(event) {
                 callback.handle_error(&err);
             }
@@ -373,10 +384,8 @@ impl Emitter for ScriptedCycleEmitter {
             .collect();
 
         // pass parameters to the mapping callback context
-        if let Some(timeout_hook) = &mut self.timeout_hook {
+        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
             timeout_hook.reset();
-        }
-        if let Some(callback) = &mut self.mapping_callback {
             if let Err(err) = callback.set_context_parameters(parameters) {
                 callback.handle_error(&err);
             }
@@ -404,11 +413,8 @@ impl Emitter for ScriptedCycleEmitter {
     fn reset(&mut self) {
         // reset cycle
         self.cycle.reset();
-        if let Some(timeout_hook) = &mut self.timeout_hook {
-            // reset timeout
+        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
             timeout_hook.reset();
-        }
-        if let Some(callback) = &mut self.mapping_callback {
             // reset step counter
             let channel = 0;
             let step = 0;

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -2,12 +2,15 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use num_traits::ToPrimitive;
 
-use mlua::prelude::{LuaError, LuaResult};
+use mlua::{
+    prelude::{LuaError, LuaResult},
+    Value,
+};
 
 use crate::{
     bindings::{
-        add_lua_callback_error, note_events_from_value, ContextPlaybackState, LuaCallback,
-        LuaTimeoutHook,
+        add_lua_callback_error, assign_cycle_vars_from_table, note_events_from_value,
+        ContextPlaybackState, LuaCallback, LuaTimeoutHook,
     },
     emitter::cycle::{apply_cycle_note_properties, CycleNoteEvents},
     BeatTimeBase, Cycle, CycleEvent, CycleSubCycle, CycleValue, Emitter, EmitterEvent, Event,
@@ -29,13 +32,18 @@ pub struct ScriptedCycleEmitter {
     parameters: Vec<(Rc<RefCell<Parameter>>, Vec<CycleSubCycle>)>,
     mappings: HashMap<String, Vec<Option<NoteEvent>>>,
     mapping_callback: Option<LuaCallback>,
+    variables_callback: Option<LuaCallback>,
     timeout_hook: Option<LuaTimeoutHook>,
     channel_steps: Vec<usize>,
 }
 
 impl ScriptedCycleEmitter {
     /// Return a new cycle with the given value mappings applied.
-    pub fn with_mappings(cycle: Cycle, mappings: Vec<(String, Vec<Option<NoteEvent>>)>) -> Self {
+    pub(crate) fn with_mappings(
+        cycle: Cycle,
+        variables_callback: Option<LuaCallback>,
+        mappings: Vec<(String, Vec<Option<NoteEvent>>)>,
+    ) -> Self {
         let parameters = vec![];
         let mappings = mappings.into_iter().collect();
         let mapping_callback = None;
@@ -46,6 +54,7 @@ impl ScriptedCycleEmitter {
             parameters,
             mappings,
             mapping_callback,
+            variables_callback,
             timeout_hook,
             channel_steps,
         }
@@ -54,6 +63,7 @@ impl ScriptedCycleEmitter {
     /// Return a new cycle with the given mapping callback applied.
     pub(crate) fn with_mapping_callback(
         cycle: Cycle,
+        variables_callback: Option<LuaCallback>,
         timeout_hook: &LuaTimeoutHook,
         mapping_callback: LuaCallback,
         time_base: &BeatTimeBase,
@@ -82,6 +92,7 @@ impl ScriptedCycleEmitter {
             parameters,
             mappings,
             mapping_callback: Some(mapping_callback),
+            variables_callback,
             timeout_hook: Some(timeout_hook),
             channel_steps,
         })
@@ -140,6 +151,42 @@ impl ScriptedCycleEmitter {
             self.cycle
                 .set_var(parameter.id(), parameter.into_var(enum_values));
         }
+
+        if let Some(variables_callback) = &mut self.variables_callback {
+            let playback_state = ContextPlaybackState::Running;
+            if let Err(err) = variables_callback.set_context_playback_state(playback_state) {
+                variables_callback.handle_error(&err);
+            }
+            if let Err(err) = variables_callback
+                .set_context_parameters(self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect())
+            {
+                variables_callback.handle_error(&err);
+            }
+
+            match variables_callback.call() {
+                Err(err) => {
+                    variables_callback.handle_error(&err);
+                }
+                Ok(value) => match value {
+                    Value::Table(table) => {
+                        if let Err(err) = assign_cycle_vars_from_table(&mut self.cycle, table) {
+                            add_lua_callback_error(None, None, "vars".to_string(), err);
+                        }
+                    }
+                    _ => {
+                        add_lua_callback_error(
+                            None,
+                            None,
+                            "vars".to_string(),
+                            LuaError::RuntimeError(
+                                "vars should return a table of variables".to_string(),
+                            ),
+                        );
+                    }
+                },
+            }
+        }
+
         // run the cycle event generator
         let events = {
             match self.cycle.generate() {

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -2,10 +2,7 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use num_traits::ToPrimitive;
 
-use mlua::{
-    prelude::{LuaError, LuaResult},
-    Value,
-};
+use mlua::prelude::{LuaError, LuaResult, LuaValue};
 
 use crate::{
     bindings::{
@@ -19,11 +16,60 @@ use crate::{
 
 // -------------------------------------------------------------------------------------------------
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum UserMapping<V: Clone, F: Clone> {
+/// Custom, user defined event mappings in cycles. Either a dynamic Lua function or static mapping table.
+/// By default an empty table (no mappings applied).
+#[derive(Debug)]
+pub(crate) enum ScriptedCycleMapping<V> {
     Table(HashMap<String, V>),
-    Function(F),
+    Function(LuaCallback),
 }
+
+impl<V> Clone for ScriptedCycleMapping<V>
+where
+    V: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::Table(t) => Self::Table(t.clone()),
+            Self::Function(f) => Self::Function(f.clone()),
+        }
+    }
+}
+
+impl<V> Default for ScriptedCycleMapping<V> {
+    fn default() -> Self {
+        Self::Table(HashMap::default())
+    }
+}
+
+impl<V> ScriptedCycleMapping<V> {
+    #[allow(unused)]
+    pub fn map(&self) -> HashMap<String, V>
+    where
+        V: Clone,
+    {
+        match self {
+            Self::Table(map) => map.clone(),
+            Self::Function(_) => HashMap::new(),
+        }
+    }
+
+    pub fn callback(&self) -> Option<&LuaCallback> {
+        match self {
+            Self::Function(f) => Some(f),
+            Self::Table(_) => None,
+        }
+    }
+
+    pub fn callback_mut(&mut self) -> Option<&mut LuaCallback> {
+        match self {
+            Self::Function(f) => Some(f),
+            Self::Table(_) => None,
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
 
 /// Emits a vector of [`EmitterEvent`]s from a [`Cycle`].
 ///
@@ -36,55 +82,65 @@ pub(crate) enum UserMapping<V: Clone, F: Clone> {
 pub struct ScriptedCycleEmitter {
     cycle: Cycle,
     parameters: Vec<(Rc<RefCell<Parameter>>, Vec<CycleSubCycle>)>,
-    mappings: UserMapping<Vec<Option<NoteEvent>>, (LuaCallback, LuaTimeoutHook)>,
-    variables_callback: Option<(LuaCallback, LuaTimeoutHook)>,
+    mappings: ScriptedCycleMapping<Vec<Option<NoteEvent>>>,
+    variable_callback: Option<LuaCallback>,
+    timeout_hook: Option<LuaTimeoutHook>,
     channel_steps: Vec<usize>,
 }
 
 impl ScriptedCycleEmitter {
+    /// Creates a new cycle emitter without mapping and variable overrides.
     pub(crate) fn new(cycle: Cycle) -> Self {
         Self {
             cycle,
             parameters: vec![],
-            mappings: UserMapping::Table(HashMap::new()),
-            variables_callback: None,
+            mappings: ScriptedCycleMapping::default(),
+            variable_callback: None,
+            timeout_hook: None,
             channel_steps: vec![],
         }
     }
 
-    /// Return a new cycle with the given value mappings applied.
-    pub(crate) fn with_mappings(self, mappings: HashMap<String, Vec<Option<NoteEvent>>>) -> Self {
-        let mappings = UserMapping::Table(mappings);
-        Self { mappings, ..self }
-    }
-
-    pub(crate) fn with_variables_callback(
+    /// Return a new cycle with the given variable callback.
+    pub(crate) fn with_variable_callback(
         self,
-        mut variables_callback: LuaCallback,
-        timeout_hook: &LuaTimeoutHook,
-    ) -> LuaResult<Self> {
-        // create a new timeout_hook instance and reset it before calling the function
-        let mut timeout_hook = timeout_hook.clone();
-        timeout_hook.reset();
-        let iteration = 0;
-        variables_callback.set_cycle_var_context(
-            self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
-            iteration,
-        )?;
-        Ok(Self {
-            variables_callback: Some((variables_callback, timeout_hook)),
-            ..self
-        })
-    }
-
-    /// Return a new cycle with the given mapping callback applied.
-    pub(crate) fn with_mapping_callback(
-        self,
-        mut mapping_callback: LuaCallback,
+        variables_callback: LuaCallback,
         timeout_hook: &LuaTimeoutHook,
         time_base: &BeatTimeBase,
     ) -> LuaResult<Self> {
         // create a new timeout_hook instance and reset it before calling the function
+        let mut timeout_hook = timeout_hook.clone();
+        timeout_hook.reset();
+        // initialize emitter context for the function
+        let playback_state = ContextPlaybackState::Running;
+        let iteration = 0;
+        let mut variable_callback = variables_callback;
+        variable_callback.set_cycle_var_context(
+            playback_state,
+            time_base,
+            &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+            iteration,
+        )?;
+        Ok(Self {
+            variable_callback: Some(variable_callback),
+            timeout_hook: Some(timeout_hook),
+            ..self
+        })
+    }
+
+    /// Return a new cycle with the given value mapping table.
+    pub(crate) fn with_mappings(self, mappings: HashMap<String, Vec<Option<NoteEvent>>>) -> Self {
+        let mappings = ScriptedCycleMapping::Table(mappings);
+        Self { mappings, ..self }
+    }
+
+    /// Return a new cycle with the given mapping callback.
+    pub(crate) fn with_mapping_callback(
+        self,
+        mapping_callback: LuaCallback,
+        timeout_hook: &LuaTimeoutHook,
+        time_base: &BeatTimeBase,
+    ) -> LuaResult<Self> {
         let mut timeout_hook = timeout_hook.clone();
         timeout_hook.reset();
         let parameters = vec![];
@@ -93,6 +149,7 @@ impl ScriptedCycleEmitter {
         let channel = 0;
         let step = 0;
         let step_length = 0.0;
+        let mut mapping_callback = mapping_callback;
         mapping_callback.set_cycle_map_context(
             playback_state,
             time_base,
@@ -100,9 +157,11 @@ impl ScriptedCycleEmitter {
             step,
             step_length,
         )?;
+        let mappings = ScriptedCycleMapping::Function(mapping_callback);
         let channel_steps = vec![];
         Ok(Self {
-            mappings: UserMapping::Function((mapping_callback, timeout_hook)),
+            mappings,
+            timeout_hook: Some(timeout_hook),
             parameters,
             channel_steps,
             ..self
@@ -119,7 +178,7 @@ impl ScriptedCycleEmitter {
     ) -> LuaResult<Vec<Option<NoteEvent>>> {
         let mut note_events = {
             match &mut self.mappings {
-                UserMapping::Function((mapping_callback, _timeout_hook)) => {
+                ScriptedCycleMapping::Function(mapping_callback) => {
                     // update step in context
                     mapping_callback.set_context_cycle_step(
                         channel_index,
@@ -130,8 +189,8 @@ impl ScriptedCycleEmitter {
                     let result = mapping_callback.call_with_arg(event.as_str().as_ref())?;
                     note_events_from_value(&result, None)?
                 }
-                UserMapping::Table(hash_map) => {
-                    if let Some(note_events) = hash_map.get(event.as_str().as_ref()) {
+                ScriptedCycleMapping::Table(mappings) => {
+                    if let Some(note_events) = mappings.get(event.as_str().as_ref()) {
                         // apply custom note mapping
                         note_events.clone()
                     } else {
@@ -143,7 +202,7 @@ impl ScriptedCycleEmitter {
         };
         // verify that all identifiers are mapped
         if (note_events.is_empty() || note_events.iter().all(|f| f.is_none()))
-            && !matches!(self.mappings, UserMapping::Function((_, _)))
+            && self.mappings.callback().is_none()
             && !matches!(event.value(), CycleValue::Rest | CycleValue::Hold)
         {
             return Err(LuaError::runtime(format!(
@@ -168,21 +227,30 @@ impl ScriptedCycleEmitter {
                 .set_var(parameter.id(), parameter.into_var(enum_values));
         }
 
-        if let Some((variables_callback, timeout_hook)) = &mut self.variables_callback {
+        // reset timeouts for mapping or variable callbacks
+        if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
-            if let Err(err) = variables_callback.set_cycle_var_context(
-                self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
-                self.cycle.iteration(),
-            ) {
+        }
+
+        // run var callback
+        if let Some(variables_callback) = &mut self.variable_callback {
+            // update context
+            if let Err(err) = variables_callback
+                .set_context_playback_state(ContextPlaybackState::Running)
+                .and(variables_callback.set_context_parameters(
+                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+                ))
+                .and(variables_callback.set_context_cycle_iteration(self.cycle.iteration()))
+            {
                 variables_callback.handle_error(&err);
             }
-
+            // run
             match variables_callback.call() {
                 Err(err) => {
                     variables_callback.handle_error(&err);
                 }
                 Ok(value) => match value {
-                    Value::Table(table) => {
+                    LuaValue::Table(table) => {
                         if let Err(err) = assign_cycle_vars_from_table(&mut self.cycle, table) {
                             add_lua_callback_error(None, None, "vars".to_string(), err);
                         }
@@ -219,15 +287,14 @@ impl ScriptedCycleEmitter {
                 }
             }
         };
-        // set callback playback state
-        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
-            // reset timeout hook for mapping functions
-            timeout_hook.reset();
-            let playback_state = ContextPlaybackState::Running;
-            if let Err(err) = callback.set_context_playback_state(playback_state) {
+
+        // set mapping callback playback state
+        if let Some(callback) = self.mappings.callback_mut() {
+            if let Err(err) = callback.set_context_playback_state(ContextPlaybackState::Running) {
                 callback.handle_error(&err);
             }
         }
+
         // convert possibly mapped cycle channel items to a list of note events
         let mut timed_note_events = CycleNoteEvents::new();
         for (channel_index, channel_events) in events.into_iter().enumerate() {
@@ -244,7 +311,7 @@ impl ScriptedCycleEmitter {
                 let step_length = length.to_f64().unwrap_or(0.0);
                 match self.cycle_to_note_event(channel_index, channel_step, step_length, event) {
                     Err(err) => {
-                        if let UserMapping::Function((callback, _timeout_hook)) = &self.mappings {
+                        if let Some(callback) = self.mappings.callback() {
                             callback.handle_error(&err)
                         } else {
                             let source = self.cycle.source().clone();
@@ -260,6 +327,7 @@ impl ScriptedCycleEmitter {
                 }
             }
         }
+
         // convert timed note events into EmitterEvents
         timed_note_events.into_event_iter_items()
     }
@@ -267,26 +335,99 @@ impl ScriptedCycleEmitter {
     /// Skip next batch of events from the cycle.
     /// This maintains cycle mapping callback states as well, if needed.
     fn advance(&mut self) {
-        match &mut self.mappings {
-            UserMapping::Function((mapping_callback, timeout_hook)) => {
-                // run the cycle event generator
-                let events = {
-                    match self.cycle.generate() {
-                        Ok(events) => events,
-                        Err(err) => {
-                            mapping_callback.handle_error(&LuaError::RuntimeError(err));
-                            return;
+        let has_stateful_callbacks = self
+            .variable_callback
+            .as_ref()
+            .is_some_and(|f| f.is_stateful().unwrap_or(true))
+            || self
+                .mappings
+                .callback()
+                .is_some_and(|f| f.is_stateful().unwrap_or(true));
+
+        if !has_stateful_callbacks {
+            // can simply advance the cycle
+            self.cycle.advance();
+            self.channel_steps.clear();
+            return;
+        }
+
+        // reset timeouts for mapping or variable callbacks
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            timeout_hook.reset();
+        }
+
+        // inject parameter values into cycle as variables
+        for (parameter_ref, enum_values) in &self.parameters {
+            let parameter = parameter_ref.borrow();
+            self.cycle
+                .set_var(parameter.id(), parameter.into_var(enum_values));
+        }
+
+        // invoke variables callback
+        if let Some(variables_callback) = &mut self.variable_callback {
+            // update context
+            if let Err(err) = variables_callback
+                .set_context_playback_state(ContextPlaybackState::Running)
+                .and(variables_callback.set_context_parameters(
+                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+                ))
+                .and(variables_callback.set_context_cycle_iteration(self.cycle.iteration()))
+            {
+                variables_callback.handle_error(&err);
+            }
+            // run
+            match variables_callback.call() {
+                Err(err) => {
+                    variables_callback.handle_error(&err);
+                }
+                Ok(value) => match value {
+                    LuaValue::Table(table) => {
+                        if let Err(err) = assign_cycle_vars_from_table(&mut self.cycle, table) {
+                            add_lua_callback_error(None, None, "vars".to_string(), err);
                         }
                     }
-                };
-                if mapping_callback.is_stateful().unwrap_or(true) {
-                    // reset timeout hooks
-                    timeout_hook.reset();
-                    // set playback state
-                    let playback_state = ContextPlaybackState::Seeking;
-                    if let Err(err) = mapping_callback.set_context_playback_state(playback_state) {
-                        mapping_callback.handle_error(&err);
+                    _ => {
+                        add_lua_callback_error(
+                            None,
+                            None,
+                            "vars".to_string(),
+                            LuaError::RuntimeError(
+                                "vars should return a table of variables".to_string(),
+                            ),
+                        );
                     }
+                },
+            }
+        }
+
+        // run the cycle event generator
+        let events = {
+            match self.cycle.generate() {
+                Ok(events) => events,
+                Err(err) => {
+                    let source = self.cycle.source().clone();
+                    let source_line = None;
+                    add_lua_callback_error(
+                        source,
+                        source_line,
+                        "advance".to_string(),
+                        LuaError::RuntimeError(err),
+                    );
+                    return;
+                }
+            }
+        };
+
+        // dry-run mappings
+        match &mut self.mappings {
+            ScriptedCycleMapping::Function(mapping_callback) => {
+                // set playback state
+                if let Err(err) =
+                    mapping_callback.set_context_playback_state(ContextPlaybackState::Seeking)
+                {
+                    mapping_callback.handle_error(&err);
+                }
+                if mapping_callback.is_stateful().unwrap_or(true) {
                     // run stateful callbacks but ignore results
                     for (channel_index, channel_events) in events.into_iter().enumerate() {
                         if self.channel_steps.len() <= channel_index {
@@ -316,7 +457,7 @@ impl ScriptedCycleEmitter {
                         }
                     }
                 } else {
-                    // advance channel_steps for generated each event
+                    // advance channel_steps for generated events
                     for (channel_index, channel_events) in events.into_iter().enumerate() {
                         if self.channel_steps.len() <= channel_index {
                             self.channel_steps.resize(channel_index + 1, 0);
@@ -325,10 +466,14 @@ impl ScriptedCycleEmitter {
                     }
                 }
             }
-            UserMapping::Table(_) => {
-                // no mapping callback present: just advance the cycle
-                self.cycle.advance();
-                self.channel_steps.clear();
+            ScriptedCycleMapping::Table(_) => {
+                // advance channel_steps for generated events
+                for (channel_index, channel_events) in events.into_iter().enumerate() {
+                    if self.channel_steps.len() <= channel_index {
+                        self.channel_steps.resize(channel_index + 1, 0);
+                    }
+                    self.channel_steps[channel_index] += channel_events.len();
+                }
             }
         }
     }
@@ -336,8 +481,15 @@ impl ScriptedCycleEmitter {
 
 impl Emitter for ScriptedCycleEmitter {
     fn set_time_base(&mut self, time_base: &BeatTimeBase) {
-        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
+        if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
+        }
+        if let Some(callback) = &mut self.variable_callback {
+            if let Err(err) = callback.set_context_time_base(time_base) {
+                callback.handle_error(&err);
+            }
+        }
+        if let Some(callback) = self.mappings.callback_mut() {
             if let Err(err) = callback.set_context_time_base(time_base) {
                 callback.handle_error(&err);
             }
@@ -345,8 +497,15 @@ impl Emitter for ScriptedCycleEmitter {
     }
 
     fn set_trigger_event(&mut self, event: &Event) {
-        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
+        if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
+        }
+        if let Some(callback) = &mut self.variable_callback {
+            if let Err(err) = callback.set_context_trigger_event(event) {
+                callback.handle_error(&err);
+            }
+        }
+        if let Some(callback) = self.mappings.callback_mut() {
             if let Err(err) = callback.set_context_trigger_event(event) {
                 callback.handle_error(&err);
             }
@@ -354,6 +513,10 @@ impl Emitter for ScriptedCycleEmitter {
     }
 
     fn set_parameters(&mut self, parameters: ParameterSet) {
+        // reset timeouts for callbacks
+        if let Some(timeout_hook) = &mut self.timeout_hook {
+            timeout_hook.reset();
+        }
         // parse and unwrap cycle subcycle values from enum parameters
         let unwrap_sub_cycle_result = |sub_cycle: Result<CycleSubCycle, String>| -> CycleSubCycle {
             sub_cycle.unwrap_or_else(|err| {
@@ -368,6 +531,7 @@ impl Emitter for ScriptedCycleEmitter {
                 CycleSubCycle::rest()
             })
         };
+        // memorize parameters
         self.parameters = parameters
             .iter()
             .map(|parameter| {
@@ -382,11 +546,15 @@ impl Emitter for ScriptedCycleEmitter {
                 )
             })
             .collect();
-
+        // pass parameters to the variables callback context
+        if let Some(callback) = &mut self.variable_callback {
+            if let Err(err) = callback.set_context_parameters(&parameters) {
+                callback.handle_error(&err);
+            }
+        }
         // pass parameters to the mapping callback context
-        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
-            timeout_hook.reset();
-            if let Err(err) = callback.set_context_parameters(parameters) {
+        if let Some(callback) = self.mappings.callback_mut() {
+            if let Err(err) = callback.set_context_parameters(&parameters) {
                 callback.handle_error(&err);
             }
         }
@@ -413,8 +581,23 @@ impl Emitter for ScriptedCycleEmitter {
     fn reset(&mut self) {
         // reset cycle
         self.cycle.reset();
-        if let UserMapping::Function((callback, timeout_hook)) = &mut self.mappings {
+        // reset timeouts for callbacks
+        if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
+        }
+        // reset callbacks
+        if let Some(callback) = &mut self.variable_callback {
+            // reset iteration counter
+            let iteration = 0;
+            if let Err(err) = callback.set_context_cycle_iteration(iteration) {
+                callback.handle_error(&err);
+            }
+            // restore function
+            if let Err(err) = callback.reset() {
+                callback.handle_error(&err);
+            }
+        }
+        if let Some(callback) = self.mappings.callback_mut() {
             // reset step counter
             let channel = 0;
             let step = 0;

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -6,7 +6,7 @@ use mlua::prelude::{LuaError, LuaResult, LuaValue};
 
 use crate::{
     bindings::{
-        add_lua_callback_error, assign_cycle_vars_from_table, note_events_from_value,
+        add_lua_callback_error, note_events_from_value, subcycle_values_from_table,
         ContextPlaybackState, LuaCallback, LuaTimeoutHook,
     },
     emitter::cycle::{apply_cycle_note_properties, CycleNoteEvents},
@@ -16,56 +16,19 @@ use crate::{
 
 // -------------------------------------------------------------------------------------------------
 
-/// Custom, user defined event mappings in cycles. Either a dynamic Lua function or static mapping table.
-/// By default an empty table (no mappings applied).
-#[derive(Debug)]
-pub(crate) enum ScriptedCycleMapping<V> {
+/// Custom, user defined event mappings or variables in cycles. Either a dynamic Lua callback
+/// or static hashmap of values.
+///
+/// By default an empty table (no custom mappings applied).
+#[derive(Debug, Clone)]
+pub(crate) enum ScriptedCycleMapping<V: Clone> {
     Table(HashMap<String, V>),
     Function(LuaCallback),
 }
 
-impl<V> Clone for ScriptedCycleMapping<V>
-where
-    V: Clone,
-{
-    fn clone(&self) -> Self {
-        match self {
-            Self::Table(t) => Self::Table(t.clone()),
-            Self::Function(f) => Self::Function(f.clone()),
-        }
-    }
-}
-
-impl<V> Default for ScriptedCycleMapping<V> {
+impl<V: Clone> Default for ScriptedCycleMapping<V> {
     fn default() -> Self {
         Self::Table(HashMap::default())
-    }
-}
-
-impl<V> ScriptedCycleMapping<V> {
-    #[allow(unused)]
-    pub fn map(&self) -> HashMap<String, V>
-    where
-        V: Clone,
-    {
-        match self {
-            Self::Table(map) => map.clone(),
-            Self::Function(_) => HashMap::new(),
-        }
-    }
-
-    pub fn callback(&self) -> Option<&LuaCallback> {
-        match self {
-            Self::Function(f) => Some(f),
-            Self::Table(_) => None,
-        }
-    }
-
-    pub fn callback_mut(&mut self) -> Option<&mut LuaCallback> {
-        match self {
-            Self::Function(f) => Some(f),
-            Self::Table(_) => None,
-        }
     }
 }
 
@@ -83,7 +46,7 @@ pub struct ScriptedCycleEmitter {
     cycle: Cycle,
     parameters: Vec<(Rc<RefCell<Parameter>>, Vec<CycleSubCycle>)>,
     mappings: ScriptedCycleMapping<Vec<Option<NoteEvent>>>,
-    variable_callback: Option<LuaCallback>,
+    variables: ScriptedCycleMapping<CycleSubCycle>,
     timeout_hook: Option<LuaTimeoutHook>,
     channel_steps: Vec<usize>,
 }
@@ -95,14 +58,30 @@ impl ScriptedCycleEmitter {
             cycle,
             parameters: vec![],
             mappings: ScriptedCycleMapping::default(),
-            variable_callback: None,
+            variables: ScriptedCycleMapping::default(),
             timeout_hook: None,
             channel_steps: vec![],
         }
     }
 
+    /// Return a new cycle with the given static variables table.
+    pub(crate) fn with_variables(self, variables: HashMap<String, CycleSubCycle>) -> Self {
+        // apply variables to cycle
+        let mut cycle = self.cycle;
+        for (name, subcycle) in variables.iter() {
+            cycle.set_var(name, subcycle.clone());
+        }
+        // return a new emitter from the modified cycle and variables
+        let variables = ScriptedCycleMapping::Table(variables);
+        Self {
+            cycle,
+            variables,
+            ..self
+        }
+    }
+
     /// Return a new cycle with the given variable callback.
-    pub(crate) fn with_variable_callback(
+    pub(crate) fn with_variables_callback(
         self,
         variables_callback: LuaCallback,
         timeout_hook: &LuaTimeoutHook,
@@ -111,24 +90,31 @@ impl ScriptedCycleEmitter {
         // create a new timeout_hook instance and reset it before calling the function
         let mut timeout_hook = timeout_hook.clone();
         timeout_hook.reset();
+        let timeout_hook = Some(timeout_hook);
         // initialize emitter context for the function
         let playback_state = ContextPlaybackState::Running;
         let iteration = 0;
-        let mut variable_callback = variables_callback;
-        variable_callback.set_cycle_var_context(
+        let mut variables_callback = variables_callback;
+        variables_callback.set_cycle_var_context(
             playback_state,
             time_base,
             &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
             iteration,
         )?;
+        // clear existing variables in cycle
+        let mut cycle = self.cycle;
+        cycle.clear_vars();
+        // return a new emitter from the modified cycle and variables
+        let variables = ScriptedCycleMapping::Function(variables_callback);
         Ok(Self {
-            variable_callback: Some(variable_callback),
-            timeout_hook: Some(timeout_hook),
+            cycle,
+            variables,
+            timeout_hook,
             ..self
         })
     }
 
-    /// Return a new cycle with the given value mapping table.
+    /// Return a new cycle with the given static mapping table.
     pub(crate) fn with_mappings(self, mappings: HashMap<String, Vec<Option<NoteEvent>>>) -> Self {
         let mappings = ScriptedCycleMapping::Table(mappings);
         Self { mappings, ..self }
@@ -143,7 +129,7 @@ impl ScriptedCycleEmitter {
     ) -> LuaResult<Self> {
         let mut timeout_hook = timeout_hook.clone();
         timeout_hook.reset();
-        let parameters = vec![];
+        let timeout_hook = Some(timeout_hook);
         // initialize emitter context for the function
         let playback_state = ContextPlaybackState::Running;
         let channel = 0;
@@ -161,8 +147,7 @@ impl ScriptedCycleEmitter {
         let channel_steps = vec![];
         Ok(Self {
             mappings,
-            timeout_hook: Some(timeout_hook),
-            parameters,
+            timeout_hook,
             channel_steps,
             ..self
         })
@@ -189,8 +174,8 @@ impl ScriptedCycleEmitter {
                     let result = mapping_callback.call_with_arg(event.as_str().as_ref())?;
                     note_events_from_value(&result, None)?
                 }
-                ScriptedCycleMapping::Table(mappings) => {
-                    if let Some(note_events) = mappings.get(event.as_str().as_ref()) {
+                ScriptedCycleMapping::Table(map) => {
+                    if let Some(note_events) = map.get(event.as_str().as_ref()) {
                         // apply custom note mapping
                         note_events.clone()
                     } else {
@@ -202,7 +187,7 @@ impl ScriptedCycleEmitter {
         };
         // verify that all identifiers are mapped
         if (note_events.is_empty() || note_events.iter().all(|f| f.is_none()))
-            && self.mappings.callback().is_none()
+            && !matches!(self.mappings, ScriptedCycleMapping::Function(_))
             && !matches!(event.value(), CycleValue::Rest | CycleValue::Hold)
         {
             return Err(LuaError::runtime(format!(
@@ -220,54 +205,16 @@ impl ScriptedCycleEmitter {
     /// Generate next batch of events from the next cycle run.
     /// Converts cycle events to note events and flattens channels into note columns.
     fn generate(&mut self) -> Vec<EmitterEvent> {
-        // inject parameter values into cycle as variables
-        for (parameter_ref, enum_values) in &self.parameters {
-            let parameter = parameter_ref.borrow();
-            self.cycle
-                .set_var(parameter.id(), parameter.into_var(enum_values));
-        }
-
         // reset timeouts for mapping or variable callbacks
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
 
-        // run var callback
-        if let Some(variables_callback) = &mut self.variable_callback {
-            // update context
-            if let Err(err) = variables_callback
-                .set_context_playback_state(ContextPlaybackState::Running)
-                .and(variables_callback.set_context_parameters(
-                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
-                ))
-                .and(variables_callback.set_context_cycle_iteration(self.cycle.iteration()))
-            {
-                variables_callback.handle_error(&err);
-            }
-            // run
-            match variables_callback.call() {
-                Err(err) => {
-                    variables_callback.handle_error(&err);
-                }
-                Ok(value) => match value {
-                    LuaValue::Table(table) => {
-                        if let Err(err) = assign_cycle_vars_from_table(&mut self.cycle, table) {
-                            add_lua_callback_error(None, None, "vars".to_string(), err);
-                        }
-                    }
-                    _ => {
-                        add_lua_callback_error(
-                            None,
-                            None,
-                            "vars".to_string(),
-                            LuaError::RuntimeError(
-                                "vars should return a table of variables".to_string(),
-                            ),
-                        );
-                    }
-                },
-            }
-        }
+        // inject parameter values into cycle as variables
+        self.apply_parameter_variables();
+
+        // inject var callback values into cycle, if present
+        self.apply_variables_callback();
 
         // run the cycle event generator
         let events = {
@@ -289,7 +236,7 @@ impl ScriptedCycleEmitter {
         };
 
         // set mapping callback playback state
-        if let Some(callback) = self.mappings.callback_mut() {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             if let Err(err) = callback.set_context_playback_state(ContextPlaybackState::Running) {
                 callback.handle_error(&err);
             }
@@ -311,7 +258,7 @@ impl ScriptedCycleEmitter {
                 let step_length = length.to_f64().unwrap_or(0.0);
                 match self.cycle_to_note_event(channel_index, channel_step, step_length, event) {
                     Err(err) => {
-                        if let Some(callback) = self.mappings.callback() {
+                        if let ScriptedCycleMapping::Function(callback) = &self.mappings {
                             callback.handle_error(&err)
                         } else {
                             let source = self.cycle.source().clone();
@@ -335,14 +282,13 @@ impl ScriptedCycleEmitter {
     /// Skip next batch of events from the cycle.
     /// This maintains cycle mapping callback states as well, if needed.
     fn advance(&mut self) {
-        let has_stateful_callbacks = self
-            .variable_callback
-            .as_ref()
-            .is_some_and(|f| f.is_stateful().unwrap_or(true))
-            || self
-                .mappings
-                .callback()
-                .is_some_and(|f| f.is_stateful().unwrap_or(true));
+        let has_stateful_callbacks = match &self.variables {
+            ScriptedCycleMapping::Function(f) => f.is_stateful().unwrap_or(true),
+            ScriptedCycleMapping::Table(_) => false,
+        } || match &self.mappings {
+            ScriptedCycleMapping::Function(f) => f.is_stateful().unwrap_or(true),
+            ScriptedCycleMapping::Table(_) => false,
+        };
 
         if !has_stateful_callbacks {
             // can simply advance the cycle
@@ -357,48 +303,10 @@ impl ScriptedCycleEmitter {
         }
 
         // inject parameter values into cycle as variables
-        for (parameter_ref, enum_values) in &self.parameters {
-            let parameter = parameter_ref.borrow();
-            self.cycle
-                .set_var(parameter.id(), parameter.into_var(enum_values));
-        }
+        self.apply_parameter_variables();
 
-        // invoke variables callback
-        if let Some(variables_callback) = &mut self.variable_callback {
-            // update context
-            if let Err(err) = variables_callback
-                .set_context_playback_state(ContextPlaybackState::Running)
-                .and(variables_callback.set_context_parameters(
-                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
-                ))
-                .and(variables_callback.set_context_cycle_iteration(self.cycle.iteration()))
-            {
-                variables_callback.handle_error(&err);
-            }
-            // run
-            match variables_callback.call() {
-                Err(err) => {
-                    variables_callback.handle_error(&err);
-                }
-                Ok(value) => match value {
-                    LuaValue::Table(table) => {
-                        if let Err(err) = assign_cycle_vars_from_table(&mut self.cycle, table) {
-                            add_lua_callback_error(None, None, "vars".to_string(), err);
-                        }
-                    }
-                    _ => {
-                        add_lua_callback_error(
-                            None,
-                            None,
-                            "vars".to_string(),
-                            LuaError::RuntimeError(
-                                "vars should return a table of variables".to_string(),
-                            ),
-                        );
-                    }
-                },
-            }
-        }
+        // inject var callback values into cycle, if present
+        self.apply_variables_callback();
 
         // run the cycle event generator
         let events = {
@@ -477,19 +385,83 @@ impl ScriptedCycleEmitter {
             }
         }
     }
+
+    fn apply_parameter_variables(&mut self) {
+        if let ScriptedCycleMapping::Table(map) = &self.variables {
+            for (parameter_ref, enum_values) in &self.parameters {
+                let parameter = parameter_ref.borrow();
+                // var overrides parameter variables, so skip this parameter
+                if !map.contains_key(parameter.id()) {
+                    self.cycle
+                        .set_var(parameter.id(), parameter.into_var(enum_values));
+                }
+            }
+        } else {
+            for (parameter_ref, enum_values) in &self.parameters {
+                let parameter = parameter_ref.borrow();
+                self.cycle
+                    .set_var(parameter.id(), parameter.into_var(enum_values));
+            }
+        }
+    }
+
+    fn apply_variables_callback(&mut self) {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
+            // update context
+            if let Err(err) = callback
+                .set_context_playback_state(ContextPlaybackState::Running)
+                .and(callback.set_context_parameters(
+                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+                ))
+                .and(callback.set_context_cycle_iteration(self.cycle.iteration()))
+            {
+                callback.handle_error(&err);
+            }
+            // run
+            match callback.call() {
+                Err(err) => {
+                    callback.handle_error(&err);
+                }
+                Ok(value) => match value {
+                    LuaValue::Table(table) => match subcycle_values_from_table(table) {
+                        Ok(variables) => {
+                            for (k, v) in variables.into_iter() {
+                                self.cycle.set_var(&k, v);
+                            }
+                        }
+                        Err(err) => {
+                            add_lua_callback_error(None, None, "vars".to_string(), err);
+                        }
+                    },
+                    _ => {
+                        add_lua_callback_error(
+                            None,
+                            None,
+                            "vars".to_string(),
+                            LuaError::RuntimeError(
+                                "vars should return a table of variables".to_string(),
+                            ),
+                        );
+                    }
+                },
+            }
+        }
+    }
 }
 
 impl Emitter for ScriptedCycleEmitter {
     fn set_time_base(&mut self, time_base: &BeatTimeBase) {
+        // reset timeouts for callbacks
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
-        if let Some(callback) = &mut self.variable_callback {
+        // pass time base to callbacks
+        if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             if let Err(err) = callback.set_context_time_base(time_base) {
                 callback.handle_error(&err);
             }
         }
-        if let Some(callback) = self.mappings.callback_mut() {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             if let Err(err) = callback.set_context_time_base(time_base) {
                 callback.handle_error(&err);
             }
@@ -497,15 +469,17 @@ impl Emitter for ScriptedCycleEmitter {
     }
 
     fn set_trigger_event(&mut self, event: &Event) {
+        // reset timeouts for callbacks
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
-        if let Some(callback) = &mut self.variable_callback {
+        // pass event to callbacks
+        if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             if let Err(err) = callback.set_context_trigger_event(event) {
                 callback.handle_error(&err);
             }
         }
-        if let Some(callback) = self.mappings.callback_mut() {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             if let Err(err) = callback.set_context_trigger_event(event) {
                 callback.handle_error(&err);
             }
@@ -517,6 +491,7 @@ impl Emitter for ScriptedCycleEmitter {
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
+
         // parse and unwrap cycle subcycle values from enum parameters
         let unwrap_sub_cycle_result = |sub_cycle: Result<CycleSubCycle, String>| -> CycleSubCycle {
             sub_cycle.unwrap_or_else(|err| {
@@ -531,7 +506,6 @@ impl Emitter for ScriptedCycleEmitter {
                 CycleSubCycle::rest()
             })
         };
-        // memorize parameters
         self.parameters = parameters
             .iter()
             .map(|parameter| {
@@ -546,14 +520,16 @@ impl Emitter for ScriptedCycleEmitter {
                 )
             })
             .collect();
+
         // pass parameters to the variables callback context
-        if let Some(callback) = &mut self.variable_callback {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             if let Err(err) = callback.set_context_parameters(&parameters) {
                 callback.handle_error(&err);
             }
         }
+
         // pass parameters to the mapping callback context
-        if let Some(callback) = self.mappings.callback_mut() {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             if let Err(err) = callback.set_context_parameters(&parameters) {
                 callback.handle_error(&err);
             }
@@ -581,12 +557,14 @@ impl Emitter for ScriptedCycleEmitter {
     fn reset(&mut self) {
         // reset cycle
         self.cycle.reset();
+
         // reset timeouts for callbacks
         if let Some(timeout_hook) = &mut self.timeout_hook {
             timeout_hook.reset();
         }
+
         // reset callbacks
-        if let Some(callback) = &mut self.variable_callback {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             // reset iteration counter
             let iteration = 0;
             if let Err(err) = callback.set_context_cycle_iteration(iteration) {
@@ -597,7 +575,7 @@ impl Emitter for ScriptedCycleEmitter {
                 callback.handle_error(&err);
             }
         }
-        if let Some(callback) = self.mappings.callback_mut() {
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             // reset step counter
             let channel = 0;
             let step = 0;

--- a/src/gate/scripted.rs
+++ b/src/gate/scripted.rs
@@ -88,7 +88,7 @@ impl Gate for ScriptedGate {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(parameters) {
+        if let Err(err) = self.callback.set_context_parameters(&parameters) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/rhythm/scripted.rs
+++ b/src/rhythm/scripted.rs
@@ -159,7 +159,7 @@ impl Rhythm for ScriptedRhythm {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(parameters) {
+        if let Err(err) = self.callback.set_context_parameters(&parameters) {
             self.callback.handle_error(&err);
         }
     }

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -185,6 +185,10 @@ impl Cycle {
         &self.source
     }
 
+    pub fn iteration(&self) -> u32 {
+        self.state.iteration
+    }
+
     /// Query for the next iteration of output.
     ///
     /// Returns error when the number of generated events exceed the configured event limit.

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -153,6 +153,14 @@ impl Cycle {
         }
     }
 
+    /// Get a custom cycle variable, as set with `set_var`.
+    pub fn get_var(&self, name: &str) -> Option<SubCycle> {
+        self.vars
+            .as_ref()
+            .and_then(|vars| vars.get(name).cloned().map(SubCycle::new))
+    }
+
+    /// Set or update a custom cycle variable.
     pub fn set_var(&mut self, name: &str, subcycle: SubCycle) {
         if let Some(vars) = self.vars.as_mut() {
             vars.insert(name.into(), subcycle.step);
@@ -163,14 +171,14 @@ impl Cycle {
         }
     }
 
-    pub fn get_var(&self, name: &str) -> Option<SubCycle> {
-        self.vars
-            .as_ref()
-            .and_then(|vars| vars.get(name).cloned().map(SubCycle::new))
-    }
-
+    /// Clear all custom cycle variables.
     pub fn clear_vars(&mut self) {
         self.vars = None
+    }
+
+    // How many times did the cycle run?
+    pub fn iteration(&self) -> u32 {
+        self.state.iteration
     }
 
     /// Check if a cycle may give different outputs between cycles.
@@ -183,10 +191,6 @@ impl Cycle {
     /// return source string indentifier (maybe a path), else None.
     pub fn source(&self) -> &Option<String> {
         &self.source
-    }
-
-    pub fn iteration(&self) -> u32 {
-        self.state.iteration
     }
 
     /// Query for the next iteration of output.

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -163,6 +163,16 @@ impl Cycle {
         }
     }
 
+    pub fn get_var(&self, name: &str) -> Option<SubCycle> {
+        self.vars
+            .as_ref()
+            .and_then(|vars| vars.get(name).cloned().map(SubCycle::new))
+    }
+
+    pub fn clear_vars(&mut self) {
+        self.vars = None
+    }
+
     /// Check if a cycle may give different outputs between cycles.
     pub fn is_stateful(&self) -> bool {
         // TODO improve: * and / can change the output, <1> does not etc..

--- a/types/pattrns/library/cycle.lua
+++ b/types/pattrns/library/cycle.lua
@@ -85,13 +85,36 @@ local Cycle = {}
 ---@nodiscard
 function Cycle:map(map) end
 
+---@alias CycleVarValue string|number|integer|boolean
+---@alias CycleVarMap {[string]: CycleVarValue}
+---@alias CycleVarFunction fun(context: CycleMapContext):CycleVarMap
+
+---Assign variables to be used inside the main cycle script via `$name` notation
+---
+---By default any parameter you define will be available to the cycle as a variable
+---but you can override and declare additional variables by passing in a table of them
+---or passing a function that can returns such a table.
+---
+---### examples:
+---```lua
+-----Using a static table
+---cycle("$a $a $b $a $b $b"):var({
+---  a = "c a f e"
+---  b = "e f a c"
+---})
+---```
+---@param variables CycleVarMap|CycleVarFunction
+---@return Cycle
+---@nodiscard
+function Cycle:var(variables) end
+
 ----------------------------------------------------------------------------------------------------
 
 ---Create a note sequence from a Tidal Cycles mini-notation string.
 ---
 ---`cycle` accepts a mini-notation as used by Tidal Cycles, with the following differences:
 ---* Stacks and random choices are valid without brackets (`a | b` is parsed as `[a | b]`)
----* `:` sets the instrument or remappable target instead of selecting samples but also 
+---* `:` sets the instrument or remappable target instead of selecting samples but also
 ---  allows setting note attributes such as instrument/volume/pan/delay (e.g. `c4:v0.1:p0.5`)
 ---* In bjorklund expressions, operators *within* and on the *right side* are not supported
 ---  (e.g. `bd(<3 2>, 8)` and `bd(3, 8)*2` are *not* supported)

--- a/types/pattrns/library/cycle.lua
+++ b/types/pattrns/library/cycle.lua
@@ -20,6 +20,14 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---step length fraction within the cycle, where 1 is the total duration of a single cycle run.
 ---@field step_length number
 
+---Context passed to 'cycle:var` functions.
+---@class CycleVarContext : TimeContext
+---
+---Specifies how the cycle currently is running.
+---@field playback PlaybackState
+---how often the cycle has been run.
+---@field iteration integer
+---
 ----------------------------------------------------------------------------------------------------
 
 ---@class Cycle
@@ -28,6 +36,7 @@ local Cycle = {}
 ----------------------------------------------------------------------------------------------------
 
 ---@alias CycleMapNoteValue NoteValue|(NoteValue[])|Note
+---@alias CycleMapTable { [string]: CycleMapNoteValue }
 ---@alias CycleMapFunction fun(context: CycleMapContext, value: string):CycleMapNoteValue
 ---@alias CycleMapGenerator fun(context: CycleMapContext, value: string):CycleMapFunction
 
@@ -80,14 +89,15 @@ local Cycle = {}
 ---  end
 ---end)
 ---```
----@param map { [string]: CycleMapNoteValue }|CycleMapFunction|CycleMapGenerator
+---@param map CycleMapTable|CycleMapFunction|CycleMapGenerator
 ---@return Cycle
 ---@nodiscard
 function Cycle:map(map) end
 
 ---@alias CycleVarValue string|number|integer|boolean
----@alias CycleVarMap {[string]: CycleVarValue}
----@alias CycleVarFunction fun(context: CycleMapContext):CycleVarMap
+---@alias CycleVarTable {[string]: CycleVarValue}
+---@alias CycleVarFunction fun(context: CycleVarContext):CycleVarTable
+---@alias CycleVarGenerator fun(context: CycleVarContext):CycleVarFunction
 
 ---Assign variables to be used inside the main cycle script via `$name` notation
 ---
@@ -103,7 +113,7 @@ function Cycle:map(map) end
 ---  b = "e f a c"
 ---})
 ---```
----@param variables CycleVarMap|CycleVarFunction
+---@param variables CycleVarTable|CycleVarFunction|CycleVarGenerator
 ---@return Cycle
 ---@nodiscard
 function Cycle:var(variables) end

--- a/types/pattrns/library/cycle.lua
+++ b/types/pattrns/library/cycle.lua
@@ -93,7 +93,7 @@ function Cycle:map(map) end
 ---
 ---By default any parameter you define will be available to the cycle as a variable
 ---but you can override and declare additional variables by passing in a table of them
----or passing a function that can returns such a table.
+---or passing a function that returns such a table.
 ---
 ---### examples:
 ---```lua

--- a/types/pattrns/library/cycle.lua
+++ b/types/pattrns/library/cycle.lua
@@ -25,9 +25,10 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---
 ---Specifies how the cycle currently is running.
 ---@field playback PlaybackState
----how often the cycle has been run.
+---Iteration counter for the cycle that increases once per the whole cycle's output
+---Starts from 1 when the cycle starts running or after it got reset.
 ---@field iteration integer
----
+
 ----------------------------------------------------------------------------------------------------
 
 ---@class Cycle


### PR DESCRIPTION
An initial draft for the discussed `vars` function on the cycle object.

Works similar to `:map` in that you can supply either a static table or a function returning a table.

I guess we'll need a different context for `vars`? Since variables are only being assigned once per `generate` instead of for each event, the fields related to single steps are meaningless.

Here, the table variant inserts the variables to the cycle directly instead of passing around the table (contrary to the case with `map`) whereas the callback variant follows a similar pattern to the `mapping_function`.

Not sure what else should happen with the callback and its errors, but it seems to work fine so far.