### PR TITLE
Adding step_time and iteration to CycleMapContext

### DIFF
--- a/docs/src/API/cycle.md
+++ b/docs/src/API/cycle.md
@@ -222,12 +222,19 @@
 > channel/voice index within the cycle. each channel in the cycle gets emitted and thus mapped
 > separately, starting with the first channel index 1.
 
+### iteration : [`integer`](../API/builtins/integer.md)<a name="iteration"></a>
+> Iteration counter for the cycle that increases once per the whole cycle's output
+> Starts from 1 when the cycle starts running or after it got reset.
+
 ### step : [`integer`](../API/builtins/integer.md)<a name="step"></a>
 > Continues step counter for each channel, incrementing with each new mapped value in the cycle.
 > Starts from 1 when the cycle starts running or after it got reset.
 
 ### step_length : [`number`](../API/builtins/number.md)<a name="step_length"></a>
 > step length fraction within the cycle, where 1 is the total duration of a single cycle run.
+
+### step_time : [`number`](../API/builtins/number.md)<a name="step_time"></a>
+> step start fraction within the cycle, where 1 is the total duration of a single cycle run.
 
 ### trigger : [`Note`](../API/note.md#Note)[`?`](../API/builtins/nil.md)<a name="trigger"></a>
 > Note that triggered the pattern, if any. Usually will be a monophonic note.

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -230,6 +230,16 @@ impl LuaCallback {
             .unwrap_or("anonymous function".to_string())
     }
 
+    /// Applies a function to itself and handles the error that may occur.
+    pub fn handle<F>(&mut self, fun: F)
+    where
+        F: FnOnce(&mut Self) -> LuaResult<()>,
+    {
+        if let Err(err) = fun(self) {
+            self.handle_error(&err);
+        }
+    }
+
     /// Sets the emitters playback state for the callback.
     pub fn set_context_playback_state(
         &mut self,

--- a/src/bindings/callback.rs
+++ b/src/bindings/callback.rs
@@ -306,11 +306,13 @@ impl LuaCallback {
         channel: usize,
         step: usize,
         step_length: f64,
+        step_time: f64,
     ) -> LuaResult<()> {
         let values = &mut self.context.borrow_mut::<CallbackContext>()?.values;
         values.insert(b"channel", (channel + 1).into());
         values.insert(b"step", step.wrapping_add(1).into());
         values.insert(b"step_length", step_length.into());
+        values.insert(b"step_time", step_time.into());
         Ok(())
     }
 
@@ -363,17 +365,17 @@ impl LuaCallback {
     }
 
     /// Sets the cycle context for the mapping callbacks.
-    pub fn set_cycle_map_context(
-        &mut self,
-        playback_state: ContextPlaybackState,
-        time_base: &BeatTimeBase,
-        channel: usize,
-        step: usize,
-        step_length: f64,
-    ) -> LuaResult<()> {
+    pub fn init_cycle_map_context(&mut self, time_base: &BeatTimeBase) -> LuaResult<()> {
+        let playback_state = ContextPlaybackState::Running;
+        let channel = 0;
+        let step = 0;
+        let step_length = 0.0;
+        let step_time = 0.0;
+        let iteration = 1;
+        self.set_context_cycle_iteration(iteration)?;
         self.set_context_playback_state(playback_state)?;
         self.set_context_time_base(time_base)?;
-        self.set_context_cycle_step(channel, step, step_length)?;
+        self.set_context_cycle_step(channel, step, step_length, step_time)?;
         Ok(())
     }
 

--- a/src/emitter/scripted.rs
+++ b/src/emitter/scripted.rs
@@ -111,27 +111,22 @@ impl Emitter for ScriptedEmitter {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new time base
-        if let Err(err) = self.callback.set_context_time_base(time_base) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_time_base(time_base));
     }
 
     fn set_trigger_event(&mut self, event: &Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_trigger_event(event) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_trigger_event(event))
     }
 
     fn set_parameters(&mut self, parameters: ParameterSet) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(&parameters) {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_parameters(&parameters));
     }
 
     fn run(&mut self, pulse: RhythmEvent, emit_event: bool) -> Option<Vec<EmitterEvent>> {
@@ -176,22 +171,14 @@ impl Emitter for ScriptedEmitter {
         self.timeout_hook.reset();
         // reset step counter
         self.step = 0;
-        if let Err(err) = self.callback.set_context_step(self.step) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_step(self.step));
         // reset pulse counter
         self.pulse_step = 0;
         self.pulse_time_step = 0.0;
-        if let Err(err) = self
-            .callback
-            .set_context_pulse_step(self.pulse_step, self.pulse_time_step)
-        {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_pulse_step(self.pulse_step, self.pulse_time_step));
         // restore function
-        if let Err(err) = self.callback.reset() {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.reset());
         // reset last event
         self.note_event_state.clear();
     }

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -210,14 +210,11 @@ impl ScriptedCycleEmitter {
 
         // set mapping callback playback state
         if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
-            if let Err(err) = callback.set_context_playback_state(ContextPlaybackState::Running) {
-                callback.handle_error(&err);
-            }
-            if let Err(err) = callback.set_context_cycle_iteration(self.cycle.iteration()) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| {
+                c.set_context_playback_state(ContextPlaybackState::Running)
+                    .and(c.set_context_cycle_iteration(self.cycle.iteration()))
+            });
         }
-
         // run the cycle event generator
         let events = {
             match self.cycle.generate() {
@@ -332,11 +329,9 @@ impl ScriptedCycleEmitter {
         match &mut self.mappings {
             ScriptedCycleMapping::Function(mapping_callback) => {
                 // set playback state
-                if let Err(err) =
-                    mapping_callback.set_context_playback_state(ContextPlaybackState::Seeking)
-                {
-                    mapping_callback.handle_error(&err);
-                }
+                mapping_callback
+                    .handle(|c| c.set_context_playback_state(ContextPlaybackState::Seeking));
+
                 if mapping_callback.is_stateful().unwrap_or(true) {
                     // run stateful callbacks but ignore results
                     for (channel_index, channel_events) in events.into_iter().enumerate() {
@@ -412,15 +407,13 @@ impl ScriptedCycleEmitter {
     fn apply_variables_callback(&mut self) {
         if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             // update context
-            if let Err(err) = callback
-                .set_context_playback_state(ContextPlaybackState::Running)
-                .and(callback.set_context_parameters(
-                    &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
-                ))
-                .and(callback.set_context_cycle_iteration(self.cycle.iteration()))
-            {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| {
+                c.set_context_playback_state(ContextPlaybackState::Running)
+                    .and(c.set_context_parameters(
+                        &self.parameters.iter().map(|(p, _)| Rc::clone(p)).collect(),
+                    ))
+                    .and(c.set_context_cycle_iteration(self.cycle.iteration()))
+            });
             // run
             match callback.call() {
                 Err(err) => {
@@ -461,14 +454,10 @@ impl Emitter for ScriptedCycleEmitter {
         }
         // pass time base to callbacks
         if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
-            if let Err(err) = callback.set_context_time_base(time_base) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_time_base(time_base));
         }
         if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
-            if let Err(err) = callback.set_context_time_base(time_base) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_time_base(time_base));
         }
     }
 
@@ -479,14 +468,10 @@ impl Emitter for ScriptedCycleEmitter {
         }
         // pass event to callbacks
         if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
-            if let Err(err) = callback.set_context_trigger_event(event) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_trigger_event(event));
         }
         if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
-            if let Err(err) = callback.set_context_trigger_event(event) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_trigger_event(event));
         }
     }
 
@@ -527,16 +512,12 @@ impl Emitter for ScriptedCycleEmitter {
 
         // pass parameters to the variables callback context
         if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
-            if let Err(err) = callback.set_context_parameters(&parameters) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_parameters(&parameters));
         }
 
         // pass parameters to the mapping callback context
         if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
-            if let Err(err) = callback.set_context_parameters(&parameters) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_parameters(&parameters));
         }
     }
 
@@ -571,13 +552,9 @@ impl Emitter for ScriptedCycleEmitter {
         if let ScriptedCycleMapping::Function(callback) = &mut self.variables {
             // reset iteration counter
             let iteration = 0;
-            if let Err(err) = callback.set_context_cycle_iteration(iteration) {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_cycle_iteration(iteration));
             // restore function
-            if let Err(err) = callback.reset() {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.reset());
         }
         if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
             // reset step counter
@@ -586,14 +563,9 @@ impl Emitter for ScriptedCycleEmitter {
             let step_length = 0.0;
             let step_time = 0.0;
             self.channel_steps.clear();
-            if let Err(err) = callback.set_context_cycle_step(channel, step, step_length, step_time)
-            {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.set_context_cycle_step(channel, step, step_length, step_time));
             // restore function
-            if let Err(err) = callback.reset() {
-                callback.handle_error(&err);
-            }
+            callback.handle(|c| c.reset());
         }
     }
 }

--- a/src/emitter/scripted_cycle.rs
+++ b/src/emitter/scripted_cycle.rs
@@ -131,18 +131,8 @@ impl ScriptedCycleEmitter {
         timeout_hook.reset();
         let timeout_hook = Some(timeout_hook);
         // initialize emitter context for the function
-        let playback_state = ContextPlaybackState::Running;
-        let channel = 0;
-        let step = 0;
-        let step_length = 0.0;
         let mut mapping_callback = mapping_callback;
-        mapping_callback.set_cycle_map_context(
-            playback_state,
-            time_base,
-            channel,
-            step,
-            step_length,
-        )?;
+        mapping_callback.init_cycle_map_context(time_base)?;
         let mappings = ScriptedCycleMapping::Function(mapping_callback);
         let channel_steps = vec![];
         Ok(Self {
@@ -159,6 +149,7 @@ impl ScriptedCycleEmitter {
         channel_index: usize,
         channel_step: usize,
         step_length: f64,
+        step_time: f64,
         event: CycleEvent,
     ) -> LuaResult<Vec<Option<NoteEvent>>> {
         let mut note_events = {
@@ -169,6 +160,7 @@ impl ScriptedCycleEmitter {
                         channel_index,
                         channel_step,
                         step_length,
+                        step_time,
                     )?;
                     // call mapping function
                     let result = mapping_callback.call_with_arg(event.as_str().as_ref())?;
@@ -216,6 +208,16 @@ impl ScriptedCycleEmitter {
         // inject var callback values into cycle, if present
         self.apply_variables_callback();
 
+        // set mapping callback playback state
+        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
+            if let Err(err) = callback.set_context_playback_state(ContextPlaybackState::Running) {
+                callback.handle_error(&err);
+            }
+            if let Err(err) = callback.set_context_cycle_iteration(self.cycle.iteration()) {
+                callback.handle_error(&err);
+            }
+        }
+
         // run the cycle event generator
         let events = {
             match self.cycle.generate() {
@@ -235,13 +237,6 @@ impl ScriptedCycleEmitter {
             }
         };
 
-        // set mapping callback playback state
-        if let ScriptedCycleMapping::Function(callback) = &mut self.mappings {
-            if let Err(err) = callback.set_context_playback_state(ContextPlaybackState::Running) {
-                callback.handle_error(&err);
-            }
-        }
-
         // convert possibly mapped cycle channel items to a list of note events
         let mut timed_note_events = CycleNoteEvents::new();
         for (channel_index, channel_events) in events.into_iter().enumerate() {
@@ -256,7 +251,14 @@ impl ScriptedCycleEmitter {
                 let start = event.span().start();
                 let length = event.span().length();
                 let step_length = length.to_f64().unwrap_or(0.0);
-                match self.cycle_to_note_event(channel_index, channel_step, step_length, event) {
+                let step_time = start.to_f64().unwrap_or(0.0);
+                match self.cycle_to_note_event(
+                    channel_index,
+                    channel_step,
+                    step_length,
+                    step_time,
+                    event,
+                ) {
                     Err(err) => {
                         if let ScriptedCycleMapping::Function(callback) = &self.mappings {
                             callback.handle_error(&err)
@@ -347,10 +349,12 @@ impl ScriptedCycleEmitter {
                             self.channel_steps[channel_index] += 1;
                             // update step in context
                             let step_length = event.span().length().to_f64().unwrap_or(0.0);
+                            let step_time = event.span().start().to_f64().unwrap_or(0.0);
                             if let Err(err) = mapping_callback.set_context_cycle_step(
                                 channel_index,
                                 channel_step,
                                 step_length,
+                                step_time,
                             ) {
                                 mapping_callback.handle_error(&err);
                                 return;
@@ -580,8 +584,10 @@ impl Emitter for ScriptedCycleEmitter {
             let channel = 0;
             let step = 0;
             let step_length = 0.0;
+            let step_time = 0.0;
             self.channel_steps.clear();
-            if let Err(err) = callback.set_context_cycle_step(channel, step, step_length) {
+            if let Err(err) = callback.set_context_cycle_step(channel, step, step_length, step_time)
+            {
                 callback.handle_error(&err);
             }
             // restore function

--- a/src/gate/scripted.rs
+++ b/src/gate/scripted.rs
@@ -70,27 +70,22 @@ impl Gate for ScriptedGate {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_time_base(time_base) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_time_base(time_base));
     }
 
     fn set_trigger_event(&mut self, event: &Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_trigger_event(event) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_trigger_event(event));
     }
 
     fn set_parameters(&mut self, parameters: ParameterSet) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(&parameters) {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_parameters(&parameters));
     }
 
     fn run(&mut self, pulse: &RhythmEvent) -> bool {
@@ -120,19 +115,9 @@ impl Gate for ScriptedGate {
         self.pulse_step = 0;
         self.pulse_time_step = 0.0;
         // update step in context
-        if let Err(err) = self
-            .callback
-            .set_context_pulse_step(self.pulse_step, self.pulse_time_step)
-        {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_pulse_step(self.pulse_step, self.pulse_time_step));
         // reset function
-        if let Err(err) = self.callback.reset() {
-            self.callback.handle_error(&err);
-        }
-        // reset function
-        if let Err(err) = self.callback.reset() {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.reset());
     }
 }

--- a/src/rhythm/scripted.rs
+++ b/src/rhythm/scripted.rs
@@ -141,27 +141,22 @@ impl Rhythm for ScriptedRhythm {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_time_base(time_base) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_time_base(time_base));
     }
 
     fn set_trigger_event(&mut self, event: &crate::Event) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context from the new time base
-        if let Err(err) = self.callback.set_context_trigger_event(event) {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.set_context_trigger_event(event));
     }
 
     fn set_parameters(&mut self, parameters: ParameterSet) {
         // reset timeout
         self.timeout_hook.reset();
         // update function context with the new parameters
-        if let Err(err) = self.callback.set_context_parameters(&parameters) {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_parameters(&parameters));
     }
 
     fn set_repeat_count(&mut self, count: Option<usize>) {
@@ -181,16 +176,10 @@ impl Rhythm for ScriptedRhythm {
         self.pulse_step = 0;
         self.pulse_time_step = 0.0;
         // update step in context
-        if let Err(err) = self
-            .callback
-            .set_context_pulse_step(self.pulse_step, self.pulse_time_step)
-        {
-            self.callback.handle_error(&err);
-        }
+        self.callback
+            .handle(|c| c.set_context_pulse_step(self.pulse_step, self.pulse_time_step));
         // reset function
-        if let Err(err) = self.callback.reset() {
-            self.callback.handle_error(&err);
-        }
+        self.callback.handle(|c| c.reset());
         // reset pulse and pulse iter
         self.pulse = None;
         self.pulse_iter = None;

--- a/types/pattrns/library/cycle.lua
+++ b/types/pattrns/library/cycle.lua
@@ -14,11 +14,16 @@ error("Do not try to execute this file. It's just a type definition file.")
 ---channel/voice index within the cycle. each channel in the cycle gets emitted and thus mapped
 ---separately, starting with the first channel index 1.
 ---@field channel integer
+---Iteration counter for the cycle that increases once per the whole cycle's output
+---Starts from 1 when the cycle starts running or after it got reset.
+---@field iteration integer
 ---Continues step counter for each channel, incrementing with each new mapped value in the cycle.
 ---Starts from 1 when the cycle starts running or after it got reset.
 ---@field step integer
 ---step length fraction within the cycle, where 1 is the total duration of a single cycle run.
 ---@field step_length number
+---step start fraction within the cycle, where 1 is the total duration of a single cycle run.
+---@field step_time number
 
 ---Context passed to 'cycle:var` functions.
 ---@class CycleVarContext : TimeContext


### PR DESCRIPTION
Implementing #81 as discussed, while also adding the `iteration` counter to the  `map` context as it's useful there as well.

I've included a helper to make the code a bit more streamlined around setting stuff on lua callbacks across the codebase while handling the error. This can be reverted of course if the more verbose way is preferred.

Note, `src/gate/scripted.rs` called `reset` on the callback twice, I assume that was a copy-paste typo.