### PR TITLE
transpose notes in cycles with target 't' using signed integers

### DIFF
--- a/src/emitter/cycle.rs
+++ b/src/emitter/cycle.rs
@@ -150,6 +150,12 @@ pub(crate) fn apply_cycle_note_properties(
                         note_event.delay = delay;
                     }
                 }
+                b"t" => {
+                    let offset = float_value_in_range(value, "transpose", -127.0..127.0)?;
+                    for note_event in note_events.iter_mut().flatten() {
+                        note_event.note = note_event.note.transposed(offset.round() as i32);
+                    }
+                }
                 b"g" => {
                     let glide = float_value_in_range(value, "glide", 0.0..)?;
                     for note_event in note_events.iter_mut().flatten() {
@@ -160,7 +166,7 @@ pub(crate) fn apply_cycle_note_properties(
                     return Err(
                         format!("invalid note property: '{name}'. ")
                             + "expecting only number values with  "
-                            + "'#' (instrument), 'v' (volume), 'p' (panning), 'd' (delay) or 'g' (glide) "
+                            + "'#' (instrument), 'v' (volume), 'p' (panning), 'd' (delay), 't' (transpose) or 'g' (glide) "
                             + "prefixes here.");
                 }
             },

--- a/src/tidal/cycle.pest
+++ b/src/tidal/cycle.pest
@@ -5,9 +5,12 @@
 WHITESPACE = _{ " " | "\t" | "\u{A0}" | NEWLINE }
 
 /// numbers types allowing [ "10" "10.0" "10." ".10" "0x1a" "0xFF" ]
-integer   = @{ "-"? ~ ((("0x" | "0X") ~ ASCII_HEX_DIGIT+) | ASCII_DIGIT+) }
+int       = @{ ((("0x" | "0X") ~ ASCII_HEX_DIGIT+) | ASCII_DIGIT+) }
+integer   = @{ "-"? ~ int }
 float     = @{ "-"? ~ (ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT*) | ("." ~ ASCII_DIGIT+) }
 number    = ${ (float | integer) ~ !ASCII_ALPHA }
+
+signed_integer = @{ ("-" | "+") ~ int }
 
 /// case-insensitive pitch type with note, optional octave and sharp or flat mark
 octave  = { "10" | ASCII_DIGIT }
@@ -16,7 +19,7 @@ note    = ${ (^"a"|^"b"|^"c"|^"d"|^"e"|^"f"|^"g") }
 pitch   = ${ note ~ mark? ~ octave? ~ !name}
 
 /// target properties such as volume "v0.1" (pattrns extension)
-target = ${ ("#" ~ (integer | variable)) | (ASCII_ALPHA ~ (float | variable)) }
+target = ${ ("#" ~ (integer | variable)) | (ASCII_ALPHA ~ (float | signed_integer | variable)) }
 /// patterns for assigning target keys with pattern on the right side
 target_name = ${ "#" | name }
 target_assign = { target_name ~ "=" ~ parameter }

--- a/src/tidal/cycle.rs
+++ b/src/tidal/cycle.rs
@@ -1460,6 +1460,10 @@ impl CycleParser {
                                 Rc::from(name),
                                 Constant::parse_float(value.as_str())?,
                             )),
+                            Rule::signed_integer => Constant::Target(Target::NamedFloat(
+                                Rc::from(name),
+                                Constant::parse_float(value.as_str())?,
+                            )),
                             Rule::variable => {
                                 return Self::variable_target(
                                     pair,

--- a/src/tidal/cycle/tests.rs
+++ b/src/tidal/cycle/tests.rs
@@ -61,6 +61,37 @@ fn weight_and_replicate() -> Result<(), String> {
 }
 
 #[test]
+fn transpose() -> Result<(), String> {
+    assert_eq!(
+        Cycle::from("a:t+1")?.generate()?,
+        [[Event::at(Fraction::from(0), Fraction::new(1, 1))
+            .with_note(9, 4)
+            .with_target(Target::named_float("t", 1.0)),]]
+    );
+    assert_eq!(
+        Cycle::from("a:t-1")?.generate()?,
+        [[Event::at(Fraction::from(0), Fraction::new(1, 1))
+            .with_note(9, 4)
+            .with_target(Target::named_float("t", -1.0)),]]
+    );
+    assert_cycles(
+        "a:t=<-12 12 0>",
+        vec![
+            vec![vec![Event::at(Fraction::from(0), Fraction::new(1, 1))
+                .with_note(9, 4)
+                .with_target(Target::named_float("t", -12.0))]],
+            vec![vec![Event::at(Fraction::from(0), Fraction::new(1, 1))
+                .with_note(9, 4)
+                .with_target(Target::named_float("t", 12.0))]],
+            vec![vec![Event::at(Fraction::from(0), Fraction::new(1, 1))
+                .with_note(9, 4)
+                .with_target(Target::named_float("t", 0.0))]],
+        ],
+    )?;
+    Ok(())
+}
+
+#[test]
 fn variables() -> Result<(), String> {
     assert!(SubCycle::from("a b c d").is_ok());
     // subcycles cannot contain variables


### PR DESCRIPTION
A draft for #93 

Adding a new allowed target type in cycles using `t` that is used in the emitter to transpose the underlying note before output.

It seems to work well and opens up some nice techniques around transposing patterns across time with alternating values etc.

A couple of things that are kinda off with this:

* Since transposition mainly makes sense with integers I had to add integers after a target in the grammar, but as stuff like `t1` could just be a name, I opted for only allowing *signed* integers in the short form, so `a:t+1` is a valid transpose but `a:t1` is not. When using patterns for the target like `[a b c]:t=<0 1 2 3>`, they don't have to be signed.
>Note, it would be nice to have `detune` features so fractional transpose would make sense, but this is a separate feature for pattrns in general.
* Under the hood, the "t" is also just a `NamedFloat`, not a new "NamedInt", I guess this is a bit misleading but probably fine and keeps the code simpler.
* While for setting properties, it make sense to have the innermost value override the outer, for transposition, it could be handy to allow for accumulation (for example `[[a b c]:t=<0 7 12>]:t=<0 3>`, where the two offsets would get added together instead of the `<0 3>` part being discarded. For a generalized syntax something like `:t+=...`  could work, this might also be nice for other properties like volume etc.

---

As an alternative to all this, I've experimented with a more generic way to allow for transposition inside the cycle (instead of leaving it for the emitter like in this PR). This isn't ready for testing yet, but still relevant here. In theory it would allow us to define operators to combine patterns, like

`[a b c] &+ <0 1 2>`

where `&` would be a prefix for all existing operators and `&+` would just be a generic addition that would work on constant types inside a cycle, so `note + number` or `note + note` would be a transposition, but `number + number` would be a regular addition (so you could generate number streams for anything like `[a b c]:t=[<0 1 2> &+ <12 24 -12>]`).

This might be a good way to leave an escape hatch in the syntax for all sorts of numeric operations and even other functionality like `[a b c d] &swing 0.3`.

---

Bringing this up because the simpler transposition implemented here overlaps with such plans and it might be better to only have one way to transpose notes.